### PR TITLE
Update Leptos crates as a group

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -16,4 +16,11 @@
   dockerfile: {
     fileMatch: ["^Earthfile$"],
   },
+
+  packageRules: [
+    {
+      matchPackagePatterns: ["^leptos"],
+      groupName: "Leptos",
+    },
+  ],
 }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,5 +17,7 @@ repository = "https://github.com/aonyx-rs/holt.git"
 rust-version = "1.81"
 
 [workspace.dependencies]
-leptos = ">=0.7.3"
+leptos = "0.7.3"
+leptos_router = "0.7.3"
+leptos_meta = "0.7.3"
 tailwind_fuse = { version = ">=0.3.0", features = ["variant"] }

--- a/crates/book/Cargo.toml
+++ b/crates/book/Cargo.toml
@@ -10,8 +10,8 @@ console_log = "1.0.0"
 holt-ui = { path = "../ui" }
 inventory = "0.3.20"
 leptos = { workspace = true, features = ["csr"] }
-leptos_router = "0.7.3"
-leptos_meta = "0.7.3"
+leptos_router = { workspace = true }
+leptos_meta = { workspace = true }
 log = "0.4.22"
 paste = "1.0.15"
 tailwind_fuse = { version = "0.3.0", features = ["variant"] }


### PR DESCRIPTION
The Leptos crates need to be updated together to prevent multiple versions of Leptos breaking the builds. The versions of the various Leptos crates have been adjusted to match the same version, and a new custom group configuration has been added to Renovate.