### PR TITLE
Fix target that formats TOML files

### DIFF
--- a/.earthly/toml/Earthfile
+++ b/.earthly/toml/Earthfile
@@ -1,12 +1,19 @@
 VERSION 0.8
 
+taplo:
+    FROM tamasfe/taplo:latest
+    SAVE ARTIFACT /taplo
+
 FORMAT:
     FUNCTION
 
     ARG FIX="false"
 
-    FROM tamasfe/taplo:latest
+    FROM alpine:latest
     WORKDIR /holt
+
+    # Copy the taplo binary into the container
+    COPY +taplo/taplo /usr/local/bin/taplo
 
     # Copy the source code into the container
     COPY . .


### PR DESCRIPTION
With versions >0.10, taplo switched to a scratch container that does not contain a shell. This prevents us from using the Docker container with Earthly, which requires a shell to run the commands in the `Earthfile`. As a workaround, we are now simply copying the binary from the official taplo container so that we can use ith in a container with a shell.