### PR TITLE
Replace `earthly/actions-setup` action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Install earthly
-        uses: earthly/actions-setup@v1
+        uses: jdno/earthly-actions-setup@v2.0.0
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           version: 0.8
@@ -54,7 +54,7 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install earthly
-        uses: earthly/actions-setup@v1
+        uses: jdno/earthly-actions-setup@v2.0.0
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           version: 0.8

--- a/.github/workflows/dependencies.yml
+++ b/.github/workflows/dependencies.yml
@@ -32,7 +32,7 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install earthly
-        uses: earthly/actions-setup@v1
+        uses: jdno/earthly-actions-setup@v2.0.0
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           version: 0.8


### PR DESCRIPTION
The `earthly/actions-setup` action is unmaintained and recently started taking much longer, since it still relied on deprecated and very recently shutdown cache servers. The action has been forked by @jdno and updated, and we are now using this fork in the continuous integration for Aonyx projects.