### PR TITLE
Extend Aonyx's Renovate configuration

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -1,17 +1,6 @@
 {
   $schema: "https://docs.renovatebot.com/renovate-schema.json",
-  extends: ["config:base"],
-
-  assignees: ["jdno"],
-  reviewers: ["jdno"],
-
-  automerge: true,
-  dependencyDashboard: false,
-  semanticCommits: "disabled",
-
-  "pre-commit": {
-    enabled: true,
-  },
+  extends: ["github>aonyx-rs/renovate-config"],
 
   dockerfile: {
     fileMatch: ["^Earthfile$"],


### PR DESCRIPTION
We use a sharable configuration preset for the Aonyx organization on GitHub, which is now being used by this repository as well.