### PR TITLE
Create `Badge` component

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -558,8 +558,10 @@ dependencies = [
  "console_error_panic_hook",
  "console_log",
  "holt-ui",
+ "icondata",
  "inventory",
  "leptos",
+ "leptos_icons",
  "leptos_meta",
  "leptos_router",
  "log",
@@ -607,6 +609,31 @@ dependencies = [
  "pin-project-lite",
  "serde",
  "throw_error",
+]
+
+[[package]]
+name = "icondata"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "278d66461d56cdaa2ff2a395e2e0b033330ed0c16171cc3f8f3f3857ea164832"
+dependencies = [
+ "icondata_core",
+ "icondata_lu",
+]
+
+[[package]]
+name = "icondata_core"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c97be924215abd5e630d84e95a47c710138a6559b4c55039f4f33aa897fa859"
+
+[[package]]
+name = "icondata_lu"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f25663a6cc5371e9e33c98bab870f4aa2fd68c88853f1467c8fccfaf112782b1"
+dependencies = [
+ "icondata_core",
 ]
 
 [[package]]
@@ -885,6 +912,16 @@ dependencies = [
  "serde",
  "syn",
  "walkdir",
+]
+
+[[package]]
+name = "leptos_icons"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2b4b2336bb146d3436c72ed885ac17c96164c54e53e8120137e722bf27d99ab"
+dependencies = [
+ "icondata_core",
+ "leptos",
 ]
 
 [[package]]

--- a/crates/book/Cargo.toml
+++ b/crates/book/Cargo.toml
@@ -8,8 +8,12 @@ edition.workspace = true
 console_error_panic_hook = "0.1.7"
 console_log = "1.0.0"
 holt-ui = { path = "../ui" }
+icondata = { version = "0.6.0", default-features = false, features = [
+  "lucide",
+] }
 inventory = "0.3.20"
 leptos = { workspace = true, features = ["csr"] }
+leptos_icons = "0.6.1"
 leptos_router = { workspace = true }
 leptos_meta = { workspace = true }
 log = "0.4.22"

--- a/crates/book/src/registry/badge.rs
+++ b/crates/book/src/registry/badge.rs
@@ -1,0 +1,59 @@
+use crate::story::{register_story, StoryAsView};
+use holt_ui::visual::{Badge, BadgeVariant, H1, H2};
+use leptos::prelude::*;
+use leptos_icons::Icon;
+
+struct BadgeStory;
+
+impl StoryAsView for BadgeStory {
+    fn as_view(&self) -> AnyView {
+        view! {
+            <>
+                <H1>Badge</H1>
+
+                <H2>Variants</H2>
+
+                <div class="flex flex-col items-center gap-2">
+                    <div class="flex w-full flex-wrap gap-2">
+                        <Badge>Default</Badge>
+                        <Badge variant=BadgeVariant::Secondary>Secondary</Badge>
+                        <Badge variant=BadgeVariant::Destructive>Destructive</Badge>
+                        <Badge variant=BadgeVariant::Outline>Outline</Badge>
+                    </div>
+                </div>
+
+                <H2>Customization</H2>
+
+                <div class="flex flex-col items-center gap-2">
+                    <div class="flex w-full flex-wrap gap-2">
+                        <Badge
+                            variant=BadgeVariant::Secondary
+                            class="bg-blue-500 text-white dark:bg-blue-600"
+                        >
+                            <Icon icon=icondata::LuBadgeCheck />
+                            Verified
+                        </Badge>
+                        <Badge class="h-5 min-w-5 rounded-full px-1 font-mono tabular-nums">
+                            8
+                        </Badge>
+                        <Badge
+                            variant=BadgeVariant::Destructive
+                            class="h-5 min-w-5 rounded-full px-1 font-mono tabular-nums"
+                        >
+                            99
+                        </Badge>
+                        <Badge
+                            variant=BadgeVariant::Outline
+                            class="h-5 min-w-5 rounded-full px-1 font-mono tabular-nums"
+                        >
+                            20+
+                        </Badge>
+                    </div>
+                </div>
+            </>
+        }
+        .into_any()
+    }
+}
+
+register_story!(BadgeStory, "Badge");

--- a/crates/book/src/registry/mod.rs
+++ b/crates/book/src/registry/mod.rs
@@ -1,1 +1,2 @@
+pub mod badge;
 pub mod button;

--- a/crates/ui/src/visual/badge.rs
+++ b/crates/ui/src/visual/badge.rs
@@ -1,0 +1,41 @@
+use leptos::prelude::*;
+use tailwind_fuse::*;
+
+#[derive(TwClass)]
+#[tw(
+    class = "inline-flex items-center justify-center rounded-md border px-2 py-0.5 text-xs font-medium w-fit whitespace-nowrap shrink-0 [&>svg]:size-3 gap-1 [&>svg]:pointer-events-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive transition-[color,box-shadow] overflow-hidden"
+)]
+struct BadgeStyle {
+    variant: BadgeVariant,
+}
+
+#[derive(TwVariant)]
+pub enum BadgeVariant {
+    #[tw(
+        default,
+        class = "border-transparent bg-primary text-primary-foreground [a&]:hover:bg-primary/90"
+    )]
+    Default,
+    #[tw(
+        class = "border-transparent bg-secondary text-secondary-foreground [a&]:hover:bg-secondary/90"
+    )]
+    Secondary,
+    #[tw(
+        class = "border-transparent bg-destructive text-white [a&]:hover:bg-destructive/90 focus-visible:ring-destructive/20 dark:focus-visible:ring-destructive/40 dark:bg-destructive/60"
+    )]
+    Destructive,
+    #[tw(class = "text-foreground [a&]:hover:bg-accent [a&]:hover:text-accent-foreground")]
+    Outline,
+}
+
+#[component]
+pub fn Badge(
+    #[prop(optional)] class: &'static str,
+    #[prop(optional)] variant: BadgeVariant,
+    // TODO: add support for behaviour like @radix-ui/react-slot?
+    // #[prop(optional)] as_child: bool,
+    children: Children,
+) -> impl IntoView {
+    let final_class = BadgeStyle { variant }.with_class(class);
+    view! { <button class=final_class>{children()}</button> }
+}

--- a/crates/ui/src/visual/mod.rs
+++ b/crates/ui/src/visual/mod.rs
@@ -1,5 +1,6 @@
 //! Components are reusable elements
 
+pub use self::badge::*;
 pub use self::breadcrumb::*;
 pub use self::button::*;
 pub use self::card::*;
@@ -7,6 +8,7 @@ pub use self::separator::*;
 pub use self::sidebar::*;
 pub use self::typography::*;
 
+mod badge;
 mod breadcrumb;
 mod button;
 mod card;


### PR DESCRIPTION
The `badge` component from shadcn/ui has been ported into this library, and a story has been added to showcase different variants.

<img width="506" alt="Screenshot 2025-07-09 at 20 41 54" src="https://github.com/user-attachments/assets/959e510e-ca8e-4dbf-b8b2-e140d23a1e24" />
