### PR TITLE
Update Docker images in Earthfiles

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -3,7 +3,7 @@
   extends: ["github>aonyx-rs/renovate-config"],
 
   dockerfile: {
-    fileMatch: ["^Earthfile$"],
+    fileMatch: ["Earthfile$"],
   },
 
   packageRules: [


### PR DESCRIPTION
The custom rule for Renovate has been updated to also update Docker images in the nested Earthfiles inside the `.earthly` directory.