### PR TITLE
Format source code for Rust 1.88.0

### DIFF
--- a/crates/book/src/docs/codegen.rs
+++ b/crates/book/src/docs/codegen.rs
@@ -83,7 +83,7 @@ impl CodeGenerator<StoryMetadata> for PhfMapGenerator {
 
         let map_tokens: TokenStream = codegen.build().to_string().parse().map_err(|e| {
             CodegenError::TokenGenerationFailed {
-                reason: format!("Failed to parse PHF map tokens: {}", e),
+                reason: format!("Failed to parse PHF map tokens: {e}"),
             }
         })?;
 

--- a/crates/book/src/docs/rustdoc.rs
+++ b/crates/book/src/docs/rustdoc.rs
@@ -210,7 +210,7 @@ mod tests {
             self.responses.get(&key).cloned().ok_or_else(|| {
                 std::io::Error::new(
                     std::io::ErrorKind::NotFound,
-                    format!("Command not found: {}", key),
+                    format!("Command not found: {key}"),
                 )
             })
         }

--- a/crates/ui/src/visual/breadcrumb.rs
+++ b/crates/ui/src/visual/breadcrumb.rs
@@ -8,7 +8,7 @@ pub fn Breadcrumb(#[prop(optional)] class: &'static str, children: Children) -> 
         if class.is_empty() {
             "flex".to_string()
         } else {
-            format!("flex {}", class)
+            format!("flex {class}")
         }
     };
 
@@ -28,8 +28,7 @@ pub fn BreadcrumbList(#[prop(optional)] class: &'static str, children: Children)
                 .to_string()
         } else {
             format!(
-                "flex flex-wrap items-center gap-1 overflow-hidden text-sm text-muted-foreground {}",
-                class
+                "flex flex-wrap items-center gap-1 overflow-hidden text-sm text-muted-foreground {class}"
             )
         }
     };
@@ -48,7 +47,7 @@ pub fn BreadcrumbItem(#[prop(optional)] class: &'static str, children: Children)
         if class.is_empty() {
             "inline-flex items-center gap-1".to_string()
         } else {
-            format!("inline-flex items-center gap-1 {}", class)
+            format!("inline-flex items-center gap-1 {class}")
         }
     };
 
@@ -70,7 +69,7 @@ pub fn BreadcrumbLink(
         if class.is_empty() {
             "transition-colors hover:text-foreground".to_string()
         } else {
-            format!("transition-colors hover:text-foreground {}", class)
+            format!("transition-colors hover:text-foreground {class}")
         }
     };
 
@@ -88,7 +87,7 @@ pub fn BreadcrumbPage(#[prop(optional)] class: &'static str, children: Children)
         if class.is_empty() {
             "font-medium text-foreground".to_string()
         } else {
-            format!("font-medium text-foreground {}", class)
+            format!("font-medium text-foreground {class}")
         }
     };
 
@@ -106,7 +105,7 @@ pub fn BreadcrumbSeparator(#[prop(optional)] class: &'static str) -> impl IntoVi
         if class.is_empty() {
             "mx-1 text-muted-foreground".to_string()
         } else {
-            format!("mx-1 text-muted-foreground {}", class)
+            format!("mx-1 text-muted-foreground {class}")
         }
     };
 

--- a/crates/ui/src/visual/separator.rs
+++ b/crates/ui/src/visual/separator.rs
@@ -28,7 +28,7 @@ pub fn Separator(
         if class.is_empty() {
             base_class.to_string()
         } else {
-            format!("{} {}", base_class, class)
+            format!("{base_class} {class}")
         }
     };
 


### PR DESCRIPTION
With Rust 1.88.0, Clippy gains a few more rules that trigger warnings on our current code base. Before being able to update Rust in CI, we need to fix this warnings.