### PR TITLE
Update CSS styles from shadcn/ui

### DIFF
--- a/crates/ui-book/public/styles.css
+++ b/crates/ui-book/public/styles.css
@@ -19,7 +19,8 @@
   --accent: oklch(0.97 0 0);
   --accent-foreground: oklch(0.205 0 0);
   --destructive: oklch(0.577 0.245 27.325);
-  --destructive-foreground: oklch(0.577 0.245 27.325);
+  /* Default destructive-foreground from shadcn/ui is broken */
+  --destructive-foreground: oklch(0.985 0 0);
   --border: oklch(0.922 0 0);
   --input: oklch(0.922 0 0);
   --ring: oklch(0.708 0 0);
@@ -55,7 +56,8 @@
   --accent: oklch(0.269 0 0);
   --accent-foreground: oklch(0.985 0 0);
   --destructive: oklch(0.396 0.141 25.723);
-  --destructive-foreground: oklch(0.637 0.237 25.331);
+  /* Default destructive-foreground from shadcn/ui is broken */
+  --destructive-foreground: oklch(0.985 0 0);
   --border: oklch(0.269 0 0);
   --input: oklch(0.269 0 0);
   --ring: oklch(0.439 0 0);


### PR DESCRIPTION
The styles from shadcn/ui[^1] have been updated to achieve a better result when porting components.

[^1]: https://ui.shadcn.com/docs/installation/manual#configure-styles