### PR TITLE
Add Textarea component

### DIFF
--- a/crates/ui-book/src/stories/mod.rs
+++ b/crates/ui-book/src/stories/mod.rs
@@ -7,3 +7,4 @@ mod collapsible;
 mod input;
 mod label;
 mod select;
+mod textarea;

--- a/crates/ui-book/src/stories/textarea.rs
+++ b/crates/ui-book/src/stories/textarea.rs
@@ -1,0 +1,81 @@
+// @component Textarea
+use holt_book::{story, variant};
+use holt_ui::visual::{Textarea, TextareaSize};
+use leptos::prelude::*;
+
+#[variant]
+fn default() -> AnyView {
+    let value = RwSignal::new(String::new());
+    view! {
+        <div class="w-80 space-y-2">
+            <Textarea value=value placeholder="Type your message here..." />
+            <p class="text-sm text-gray-600">"Character count: " {move || value.get().len()}</p>
+        </div>
+    }
+    .into_any()
+}
+
+#[variant]
+fn sizes() -> AnyView {
+    let v1 = RwSignal::new(String::new());
+    let v2 = RwSignal::new(String::new());
+    let v3 = RwSignal::new(String::new());
+    view! {
+        <div class="w-80 space-y-3">
+            <Textarea size=TextareaSize::Sm value=v1 placeholder="Small" />
+            <Textarea value=v2 placeholder="Default" />
+            <Textarea size=TextareaSize::Lg value=v3 placeholder="Large" />
+        </div>
+    }
+    .into_any()
+}
+
+#[variant]
+fn disabled() -> AnyView {
+    let value = RwSignal::new("This textarea is disabled".to_string());
+    view! {
+        <div class="w-80">
+            <Textarea value=value disabled=true />
+        </div>
+    }
+    .into_any()
+}
+
+#[variant]
+fn with_label_and_help() -> AnyView {
+    let value = RwSignal::new(String::new());
+    view! {
+        <div class="w-80 space-y-2">
+            <label for="bio" class="text-sm font-medium leading-none">
+                "Bio"
+            </label>
+            <Textarea
+                id="bio"
+                name="bio"
+                value=value
+                placeholder="Tell us about yourself..."
+            />
+            <p class="text-xs text-muted-foreground">
+                "You can use markdown syntax for formatting."
+            </p>
+        </div>
+    }
+    .into_any()
+}
+
+#[variant]
+fn custom_rows() -> AnyView {
+    let value = RwSignal::new(String::new());
+    view! {
+        <div class="w-80 space-y-2">
+            <Textarea value=value placeholder="Custom height with 10 rows" rows=10 />
+        </div>
+    }
+    .into_any()
+}
+
+include!(concat!(env!("OUT_DIR"), "/stories/textarea_source.rs"));
+
+#[story(id = "textarea", name = "Textarea", extra_docs = TEXTAREA_SOURCE)]
+/// `value` is two‑way bound (`bind:value`).
+const TEXTAREA_STORY: () = &[default, sizes, disabled, with_label_and_help, custom_rows];

--- a/crates/ui/src/visual/mod.rs
+++ b/crates/ui/src/visual/mod.rs
@@ -11,6 +11,7 @@ pub use self::label::*;
 pub use self::select::*;
 pub use self::separator::*;
 pub use self::sidebar::*;
+pub use self::textarea::*;
 pub use self::typography::*;
 
 mod badge;
@@ -24,4 +25,5 @@ mod label;
 mod select;
 mod separator;
 mod sidebar;
+mod textarea;
 mod typography;

--- a/crates/ui/src/visual/textarea.rs
+++ b/crates/ui/src/visual/textarea.rs
@@ -1,0 +1,57 @@
+use leptos::prelude::*;
+use tailwind_fuse::*;
+
+#[derive(TwClass)]
+#[tw(
+    class = "flex min-h-[80px] w-full rounded-md border border-input bg-background px-3 text-sm ring-offset-background placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-[3px] focus-visible:ring-ring/50 disabled:cursor-not-allowed disabled:opacity-50"
+)]
+struct TextareaStyle {
+    size: TextareaSize,
+}
+
+#[derive(TwVariant)]
+pub enum TextareaSize {
+    #[tw(default, class = "py-2 min-h-[80px]")]
+    Default,
+    #[tw(class = "py-1.5 text-sm min-h-[60px]")]
+    Sm,
+    #[tw(class = "py-2.5 text-base min-h-[100px]")]
+    Lg,
+}
+
+#[component]
+pub fn Textarea(
+    #[prop(optional)] class: &'static str,
+    #[prop(optional)] size: TextareaSize,
+    /// Two‑way bound via `bind:value`.
+    #[prop(optional, default = RwSignal::new(String::new()))]
+    value: RwSignal<String>,
+    #[prop(optional, into)] disabled: Signal<bool>,
+    #[prop(optional, into)] readonly: Signal<bool>,
+    #[prop(optional, into)] required: Signal<bool>,
+    #[prop(optional_no_strip, into)] id: Option<&'static str>,
+    #[prop(optional_no_strip, into)] name: Option<&'static str>,
+    #[prop(optional_no_strip, into)] placeholder: Option<&'static str>,
+    #[prop(optional_no_strip, into)] rows: Option<u32>,
+    #[prop(optional_no_strip, into)] cols: Option<u32>,
+) -> impl IntoView {
+    let class = TextareaStyle { size }.with_class(class);
+
+    view! {
+        <textarea
+            class=class
+            bind:value=value
+            id=id
+            name=name
+            placeholder=placeholder
+            rows=rows
+            cols=cols
+            disabled=disabled
+            readonly=readonly
+            required=required
+            data-invalid=move || {
+                if required.get() && value.get().is_empty() { Some("true") } else { None }
+            }
+        />
+    }
+}


### PR DESCRIPTION
Implemented a new Textarea component following the existing Input component pattern:

- Created visual/textarea.rs with Shadcn-style styling
- Added size variants (Small, Default, Large)
- Supports two-way binding via bind:value
- Includes disabled, readonly, and required states
- Added comprehensive storybook with 5 variants

The component follows the established pattern for simple form elements and does not require a separate behavior layer.

Fixes #120

---

Generated with [Claude Code](https://claude.ai/code)