### PR TITLE
Fix Claude Code Review workflow credential issue

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -33,7 +33,7 @@ jobs:
         uses: actions/checkout@v5
         with:
           fetch-depth: 1
-          persist-credentials: false
+          persist-credentials: true
 
       - name: Run Claude Code Review
         id: claude-review


### PR DESCRIPTION
Change persist-credentials to true to allow Git operations within the action