### PR TITLE
Fix SSG panic: initialize tokio executor for Leptos SSR

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -248,6 +248,7 @@ checksum = "1384d3fe1eecb464229fcf6eebb72306591c56bf27b373561489458a7c73027d"
 dependencies = [
  "futures",
  "thiserror 2.0.17",
+ "tokio",
  "wasm-bindgen-futures",
 ]
 
@@ -2245,6 +2246,7 @@ dependencies = [
 name = "holt-kit-docs"
 version = "0.0.0"
 dependencies = [
+ "any_spawner",
  "eframe",
  "holt-book",
  "holt-kit",

--- a/crates/kit-docs/Cargo.toml
+++ b/crates/kit-docs/Cargo.toml
@@ -15,6 +15,7 @@ icondata = { version = "0.7.0", default-features = false, features = [
 ] }
 leptos_icons = "0.7.0"
 inventory = "0.3.20"
+any_spawner = { version = "0.3.0", features = ["tokio"], optional = true }
 thirtyfour = { version = "0.36.0", optional = true }
 tokio = { version = "1.41", features = ["full"], optional = true }
 ureq = { version = "3.0", optional = true }
@@ -24,7 +25,14 @@ image = { version = "0.25", optional = true, features = ["png"] }
 [features]
 default = ["csr"]
 csr = ["holt-book/csr", "leptos/csr"]
-ssr = ["holt-book/ssr", "leptos/ssr", "leptos_router/ssr", "leptos_meta/ssr"]
+ssr = [
+  "holt-book/ssr",
+  "leptos/ssr",
+  "leptos_router/ssr",
+  "leptos_meta/ssr",
+  "any_spawner",
+  "tokio",
+]
 hydrate = ["holt-book/hydrate", "leptos/hydrate"]
 visual-regression = ["thirtyfour", "tokio", "ureq", "eframe", "image"]
 

--- a/crates/kit-docs/src/bin/ssg.rs
+++ b/crates/kit-docs/src/bin/ssg.rs
@@ -91,10 +91,24 @@ fn wrap_in_html_document(body: &str, title: &str) -> String {
     )
 }
 
-fn main() {
+#[tokio::main]
+async fn main() {
+    // Initialize the executor so Leptos effects can spawn futures
+    any_spawner::Executor::init_tokio().expect("Failed to initialize tokio executor");
+
     // Initialize the story registry for SSR
     init_for_ssr();
 
+    // Leptos effects use spawn_local which requires a LocalSet in tokio
+    let local = tokio::task::LocalSet::new();
+    local
+        .run_until(async {
+            generate_static_site().await;
+        })
+        .await;
+}
+
+async fn generate_static_site() {
     let output_dir = std::env::args()
         .nth(1)
         .unwrap_or_else(|| "docs/static/kit".to_string());


### PR DESCRIPTION
## Summary
- Leptos effects internally use `spawn_local` which requires a global executor and a tokio `LocalSet`
- Added `any_spawner` and `tokio` as SSR feature dependencies
- Wrapped SSG rendering in `#[tokio::main]` + `LocalSet::run_until`

## Test plan
- [x] `cargo run -p holt-kit-docs --bin ssg --features ssr --no-default-features` succeeds locally
- [ ] Deploy Documentation workflow passes on main

🤖 Generated with [Claude Code](https://claude.com/claude-code)