### PR TITLE
Fix docs workflow: add pages permissions to build job

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -26,6 +26,8 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
+      pages: write
+      id-token: write
     steps:
       - name: Checkout
         uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # 6.0.1


### PR DESCRIPTION
## Summary
- `actions/configure-pages` in the build job needs `pages: write` and `id-token: write` permissions
- These were only granted to the deploy job, causing the build to fail with "Resource not accessible by integration"

## Test plan
- [ ] Deploy Documentation workflow passes after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)