### PR TITLE
Add WASM hydration to SSG kit storybook pages

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -40,6 +40,13 @@ jobs:
       - name: Cache Rust dependencies
         uses: Swatinem/rust-cache@779680da715d629ac1d338a641029a2f4372abb5 # 2.8.2
 
+      - name: Build Kit WASM hydration bundle
+        uses: flox/activate-action@410568008895a0f2e09a34bbd9523f8ef1f2d292 # 1.1.0
+        with:
+          command: |
+            wasm-pack build crates/kit-docs --target web --out-dir ../../docs/static/kit --out-name hydrate --no-default-features --features hydrate --release
+            rm -f docs/static/kit/package.json docs/static/kit/.gitignore docs/static/kit/hydrate.d.ts docs/static/kit/hydrate_bg.wasm.d.ts
+
       - name: Generate Kit Storybook static files
         uses: flox/activate-action@410568008895a0f2e09a34bbd9523f8ef1f2d292 # 1.1.0
         with:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2247,6 +2247,7 @@ name = "holt-kit-docs"
 version = "0.0.0"
 dependencies = [
  "any_spawner",
+ "console_error_panic_hook",
  "eframe",
  "holt-book",
  "holt-kit",
@@ -2262,6 +2263,7 @@ dependencies = [
  "thiserror 1.0.69",
  "tokio",
  "ureq",
+ "wasm-bindgen",
 ]
 
 [[package]]

--- a/crates/book/src/lib.rs
+++ b/crates/book/src/lib.rs
@@ -30,3 +30,8 @@ pub fn run_book() {
 pub fn init_for_ssr() {
     init_story_registry();
 }
+
+#[cfg(feature = "hydrate")]
+pub fn init_for_hydrate() {
+    init_story_registry();
+}

--- a/crates/book/src/ui/app.rs
+++ b/crates/book/src/ui/app.rs
@@ -31,12 +31,45 @@ pub fn get_static_routes() -> Vec<String> {
 }
 
 #[component]
+fn KitNavbar() -> impl IntoView {
+    view! {
+        <nav class="kit-navbar">
+            <div class="kit-navbar-inner">
+                <a href="/" class="kit-navbar-logo">
+                    <img src="/img/logo.svg" alt="Holt" height="32" />
+                </a>
+                <div class="kit-navbar-items">
+                    <a href="/docs/tutorials/" class="kit-navbar-link">
+                        "Docs"
+                    </a>
+                    <a href="/kit/" class="kit-navbar-link kit-navbar-link--active">
+                        "Kit"
+                    </a>
+                </div>
+                <div class="kit-navbar-items kit-navbar-right">
+                    <a
+                        href="https://github.com/aonyx-labs/holt"
+                        class="kit-navbar-link"
+                        target="_blank"
+                        rel="noopener noreferrer"
+                    >
+                        "GitHub"
+                    </a>
+                </div>
+            </div>
+        </nav>
+    }
+}
+
+#[component]
 pub fn App(#[prop(optional)] base: &'static str) -> impl IntoView {
     // Provides context that manages stylesheets, titles, meta tags, etc.
     provide_meta_context();
 
     // Provide base path context for components that need it
     provide_context(BasePath(base));
+
+    let show_navbar = !base.is_empty();
 
     view! {
         <Html attr:lang="en" attr:dir="ltr" attr:data-theme="light" />
@@ -48,14 +81,18 @@ pub fn App(#[prop(optional)] base: &'static str) -> impl IntoView {
         <Meta charset="UTF-8" />
         <Meta name="viewport" content="width=device-width, initial-scale=1.0" />
 
-        <Router base=base>
-            <Routes fallback=|| "not found">
-                <Route
-                    path=path!("/visual-test/:story_id/:variant_index")
-                    view=move || view! { <VisualTestStory /> }
-                />
-                <Route path=path!("/*any") view=move || view! { <Storybook /> } />
-            </Routes>
-        </Router>
+        {show_navbar.then(|| view! { <KitNavbar /> })}
+
+        <div class=if show_navbar { "kit-content" } else { "" }>
+            <Router base=base>
+                <Routes fallback=|| "not found">
+                    <Route
+                        path=path!("/visual-test/:story_id/:variant_index")
+                        view=move || view! { <VisualTestStory /> }
+                    />
+                    <Route path=path!("/*any") view=move || view! { <Storybook /> } />
+                </Routes>
+            </Router>
+        </div>
     }
 }

--- a/crates/kit-docs/Cargo.toml
+++ b/crates/kit-docs/Cargo.toml
@@ -4,6 +4,9 @@ name = "holt-kit-docs"
 version.workspace = true
 edition.workspace = true
 
+[lib]
+crate-type = ["cdylib", "rlib"]
+
 [dependencies]
 leptos = { workspace = true }
 leptos_router = { workspace = true }
@@ -15,6 +18,8 @@ icondata = { version = "0.7.0", default-features = false, features = [
 ] }
 leptos_icons = "0.7.0"
 inventory = "0.3.20"
+console_error_panic_hook = { version = "0.1.7", optional = true }
+wasm-bindgen = { version = "0.2", optional = true }
 any_spawner = { version = "0.3.0", features = ["tokio"], optional = true }
 thirtyfour = { version = "0.36.0", optional = true }
 tokio = { version = "1.41", features = ["full"], optional = true }
@@ -33,7 +38,12 @@ ssr = [
   "any_spawner",
   "tokio",
 ]
-hydrate = ["holt-book/hydrate", "leptos/hydrate"]
+hydrate = [
+  "holt-book/hydrate",
+  "leptos/hydrate",
+  "wasm-bindgen",
+  "console_error_panic_hook",
+]
 visual-regression = ["thirtyfour", "tokio", "ureq", "eframe", "image"]
 
 [build-dependencies]

--- a/crates/kit-docs/justfile
+++ b/crates/kit-docs/justfile
@@ -58,6 +58,11 @@ load-baselines-from-gh-artifact run_id:
     echo "Next steps:"
     echo "  git add crates/kit-docs/tests/visual-baselines/ && git commit -m 'accept new visual baselines'"
 
+# Build WASM hydration bundle for SSG pages
+build-hydrate:
+    wasm-pack build . --target web --out-dir ../../docs/static/kit --out-name hydrate --no-default-features --features hydrate --release
+    rm -f ../../docs/static/kit/package.json ../../docs/static/kit/.gitignore ../../docs/static/kit/hydrate.d.ts ../../docs/static/kit/hydrate_bg.wasm.d.ts
+
 # Render a single story variant to PNG (for LLM agent use)
 # The <variant> can be either an index (0, 1, 2...) or a name ('default', 'destructive'...)
 # Examples:

--- a/crates/kit-docs/src/bin/ssg.rs
+++ b/crates/kit-docs/src/bin/ssg.rs
@@ -24,25 +24,6 @@ fn get_all_stories() -> Vec<&'static Story> {
 /// Base path for the kit documentation (used when serving from /kit/ in Docusaurus)
 const BASE_PATH: &str = "/kit";
 
-fn render_navbar() -> &'static str {
-    r#"<nav class="kit-navbar">
-    <div class="kit-navbar-inner">
-        <a href="/" class="kit-navbar-logo">
-            <img src="/img/logo.svg" alt="Holt" height="32" />
-        </a>
-        <div class="kit-navbar-items">
-            <a href="/docs/tutorials/" class="kit-navbar-link">Docs</a>
-            <a href="/kit/" class="kit-navbar-link kit-navbar-link--active">Kit</a>
-        </div>
-        <div class="kit-navbar-items kit-navbar-right">
-            <a href="https://github.com/aonyx-labs/holt" class="kit-navbar-link" target="_blank" rel="noopener noreferrer">
-                GitHub
-            </a>
-        </div>
-    </div>
-</nav>"#
-}
-
 fn render_route_to_html(route: &str) -> String {
     // Create a new reactive owner for this render
     let owner = Owner::new();
@@ -77,15 +58,16 @@ fn wrap_in_html_document(body: &str, title: &str) -> String {
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>{title}</title>
     <link rel="stylesheet" href="/kit/styles.css">
+    <link rel="preload" href="/kit/hydrate_bg.wasm" as="fetch" crossorigin>
+    <script type="module">
+      import init from '/kit/hydrate.js';
+      init('/kit/hydrate_bg.wasm');
+    </script>
 </head>
 <body class="kit-body">
-{navbar}
-<div class="kit-content">
 {body}
-</div>
 </body>
 </html>"#,
-        navbar = render_navbar(),
         title = title,
         body = body
     )

--- a/crates/kit-docs/src/lib.rs
+++ b/crates/kit-docs/src/lib.rs
@@ -1,1 +1,13 @@
 pub mod stories;
+
+#[cfg(feature = "hydrate")]
+#[wasm_bindgen::prelude::wasm_bindgen(start)]
+pub fn hydrate() {
+    holt_book::init_for_hydrate();
+
+    console_error_panic_hook::set_once();
+
+    leptos::mount::hydrate_body(move || {
+        leptos::view! { <holt_book::App base="/kit" /> }
+    });
+}


### PR DESCRIPTION
## Summary
- SSG-generated kit storybook pages at `/kit/` are currently pure static HTML — interactive components (Select, Collapsible, Toggle, etc.) don't work
- This adds full WASM hydration via `wasm-pack build` so Leptos hydrates the static HTML and makes everything interactive
- Moves the navbar into the Leptos App component so SSR and hydration produce identical DOM (required for hydration to work)

## Changes
- **`crates/book/src/ui/app.rs`**: Added `KitNavbar` component rendered when `base` prop is set; wrapped router in `kit-content` div
- **`crates/kit-docs/src/lib.rs`**: Added `#[wasm_bindgen(start)]` hydrate entry point
- **`crates/book/src/lib.rs`**: Added `init_for_hydrate()` (hydrate-gated)
- **`crates/kit-docs/src/bin/ssg.rs`**: Removed `render_navbar()`, added WASM preload + module script tags
- **`crates/kit-docs/Cargo.toml`**: Added `cdylib` crate-type, `wasm-bindgen` + `console_error_panic_hook` deps
- **`crates/kit-docs/justfile`**: Added `build-hydrate` command
- **`.github/workflows/docs.yml`**: Added wasm-pack build step before SSG

## Test plan
- [ ] `wasm-pack build crates/kit-docs --target web --out-name hydrate --no-default-features --features hydrate` succeeds
- [ ] `cargo run -p holt-kit-docs --bin ssg --features ssr --no-default-features` still generates pages
- [ ] Serve output locally and verify components are interactive (buttons click, selects open, collapsibles toggle)
- [ ] `just kit-docs serve` (CSR dev) still works
- [ ] `just pre-commit` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)