### PR TITLE
Use trunk for ssg build

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -42,12 +42,10 @@ jobs:
       - name: Cache Rust dependencies
         uses: Swatinem/rust-cache@779680da715d629ac1d338a641029a2f4372abb5 # 2.8.2
 
-      - name: Build Kit WASM hydration bundle
+      - name: Build Kit WASM + CSS with Trunk
         uses: flox/activate-action@410568008895a0f2e09a34bbd9523f8ef1f2d292 # 1.1.0
         with:
-          command: |
-            wasm-pack build crates/kit-docs --target web --out-dir ../../docs/static/kit --out-name hydrate --no-default-features --features hydrate --release
-            rm -f docs/static/kit/package.json docs/static/kit/.gitignore docs/static/kit/hydrate.d.ts docs/static/kit/hydrate_bg.wasm.d.ts
+          command: cd crates/kit-docs && trunk build --release --filehash false --no-default-features --features hydrate
 
       - name: Generate Kit Storybook static files
         uses: flox/activate-action@410568008895a0f2e09a34bbd9523f8ef1f2d292 # 1.1.0

--- a/crates/kit-docs/index.html
+++ b/crates/kit-docs/index.html
@@ -8,7 +8,13 @@
     <link data-trunk rel="icon" href="public/favicon.ico" />
 
     <!-- include support for `wasm-bindgen --weak-refs` - see: https://rustwasm.github.io/docs/wasm-bindgen/reference/weak-references.html -->
-    <link data-trunk rel="rust" data-wasm-opt="z" data-weak-refs />
+    <link
+      data-trunk
+      rel="rust"
+      data-target-name="holt_kit_docs"
+      data-wasm-opt="z"
+      data-weak-refs
+    />
   </head>
 
   <body></body>

--- a/crates/kit-docs/src/bin/ssg.rs
+++ b/crates/kit-docs/src/bin/ssg.rs
@@ -58,10 +58,10 @@ fn wrap_in_html_document(body: &str, title: &str) -> String {
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>{title}</title>
     <link rel="stylesheet" href="/kit/styles.css">
-    <link rel="preload" href="/kit/hydrate_bg.wasm" as="fetch" crossorigin>
+    <link rel="preload" href="/kit/holt-kit-docs_bg.wasm" as="fetch" crossorigin>
     <script type="module">
-      import init from '/kit/hydrate.js';
-      init('/kit/hydrate_bg.wasm');
+      import init from '/kit/holt-kit-docs.js';
+      init('/kit/holt-kit-docs_bg.wasm');
     </script>
 </head>
 <body class="kit-body">
@@ -129,36 +129,25 @@ async fn generate_static_site() {
         println!("  Generated: {}", story_path.display());
     }
 
-    // Copy compiled styles.css to output directory
-    // First try dist/ (compiled), then fall back to public/ (source)
+    // Copy trunk build artifacts (CSS, JS, WASM) from dist/ to output directory
     let dist_dir = Path::new("crates/kit-docs/dist");
-    let styles_dest = output_path.join("styles.css");
+    let assets = ["styles.css", "holt-kit-docs.js", "holt-kit-docs_bg.wasm"];
 
-    let copied = if dist_dir.exists() {
-        // Find the compiled CSS file (has hash in name)
-        fs::read_dir(dist_dir)
-            .ok()
-            .and_then(|entries| {
-                entries.filter_map(|e| e.ok()).find(|e| {
-                    e.path()
-                        .file_name()
-                        .and_then(|n| n.to_str())
-                        .is_some_and(|n| n.starts_with("styles") && n.ends_with(".css"))
-                })
-            })
-            .map(|entry| {
-                fs::copy(entry.path(), &styles_dest).expect("Failed to copy styles.css");
-                true
-            })
-            .unwrap_or(false)
+    if dist_dir.exists() {
+        for asset in &assets {
+            let src = dist_dir.join(asset);
+            let dest = output_path.join(asset);
+            if src.exists() {
+                fs::copy(&src, &dest).unwrap_or_else(|e| panic!("Failed to copy {}: {}", asset, e));
+                println!("  Copied: {}", dest.display());
+            } else {
+                eprintln!("  Warning: {} not found in dist/", asset);
+            }
+        }
     } else {
-        false
-    };
-
-    if copied {
-        println!("  Copied: {}", styles_dest.display());
-    } else {
-        eprintln!("  Warning: No compiled styles.css found in dist/. Run `trunk build` first.");
+        eprintln!(
+            "  Warning: dist/ not found. Run `trunk build --release --filehash false --no-default-features --features hydrate` first."
+        );
     }
 
     println!("\nStatic site generation complete!");


### PR DESCRIPTION
The CI workflow was using wasm-pack for the WASM hydration bundle but had no step to compile Tailwind CSS, so styles.css was missing from deploys. Switch to trunk which handles both WASM compilation and CSS processing in a single build step, fixing the missing styles and simplifying the pipeline.