### PR TITLE
Fix hydration: add leptos_meta HEAD marker comment

### DIFF
--- a/crates/kit-docs/src/bin/ssg.rs
+++ b/crates/kit-docs/src/bin/ssg.rs
@@ -57,6 +57,7 @@ fn wrap_in_html_document(body: &str, title: &str) -> String {
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>{title}</title>
+    <!--HEAD-->
     <link rel="stylesheet" href="/kit/styles.css">
     <link rel="preload" href="/kit/holt-kit-docs_bg.wasm" as="fetch" crossorigin>
     <script type="module">


### PR DESCRIPTION
## Summary
- Add `<!--HEAD-->` marker comment to the SSG HTML template that `leptos_meta` requires for hydration
- Without this marker, the WASM hydration bundle panics on page load

## Test plan
- [ ] Verify holt.rs/kit loads without console errors after deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)