### PR TITLE
Fix hydration panic: remove whitespace text nodes in body

### DIFF
--- a/crates/kit-docs/src/bin/ssg.rs
+++ b/crates/kit-docs/src/bin/ssg.rs
@@ -65,9 +65,7 @@ fn wrap_in_html_document(body: &str, title: &str) -> String {
       init('/kit/holt-kit-docs_bg.wasm');
     </script>
 </head>
-<body class="kit-body">
-{body}
-</body>
+<body class="kit-body">{body}</body>
 </html>"#,
         title = title,
         body = body


### PR DESCRIPTION
## Summary
- Remove newlines between `<body>` tag and SSR content in the SSG template
- The whitespace created a text node as the first child of `<body>`, causing the tachys hydration cursor to panic when it expected a `<nav>` element

## Test plan
- [ ] Verify holt.rs/kit loads without console errors after deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)