### PR TITLE
Fix hydration: use to_html_branching() for SSG output

### DIFF
--- a/crates/kit-docs/src/bin/ssg.rs
+++ b/crates/kit-docs/src/bin/ssg.rs
@@ -40,8 +40,8 @@ fn render_route_to_html(route: &str) -> String {
     // Render the App component to HTML with base path
     let html = owner.with(|| {
         let app = App(AppProps { base: BASE_PATH });
-        // Use Leptos's to_html() method available in SSR mode
-        app.to_html()
+        // Use to_html_branching() to emit branch marker comments needed for hydration
+        app.to_html_branching()
     });
 
     owner.cleanup();


### PR DESCRIPTION
## Summary
- Switch SSG from `to_html()` to `to_html_branching()` to emit branch marker comments (`<!--bo-0-->`, `<!--bc-0-->`) that the tachys hydration code needs to walk the DOM for conditionals and `Either` types
- `to_html()` sets `mark_branches: false`, so the hydration cursor couldn't find the expected comment nodes and panicked with `unreachable!()`

## Test plan
- [ ] Verify holt.rs/kit loads without console errors after deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)