### PR TITLE
Revert to to_html() — branch markers break hydration

### DIFF
--- a/crates/kit-docs/src/bin/ssg.rs
+++ b/crates/kit-docs/src/bin/ssg.rs
@@ -38,10 +38,10 @@ async fn render_route_to_html(route: &str, title: &str) -> String {
     let (meta_context, meta_output) = ServerMetaContext::new();
     provide_context(meta_context);
 
-    // Render the App component to HTML with branch markers for hydration
+    // Render the App component to HTML
     let body_html = owner.with(|| {
         let app = App(AppProps { base: BASE_PATH });
-        app.to_html_branching()
+        app.to_html()
     });
 
     // Build the HTML shell with bare <html> and <body> tags for inject_meta_context to fill in


### PR DESCRIPTION
## Summary
- Switch SSG back from `to_html_branching()` to `to_html()`
- The branch marker comments (`<!--bo-0-->`, `<!--bc-0-->`) are only used for DOM diffing/rebuilding, not initial hydration — the hydration cursor doesn't expect them and panics when it encounters unexpected comment nodes

## Test plan
- [ ] Verify holt.rs/kit loads without hydration panic after deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)