### PR TITLE
Extract leptos-floating crate and fix alignment bugs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2235,6 +2235,7 @@ dependencies = [
  "console_log",
  "icondata",
  "leptos",
+ "leptos-floating",
  "leptos_icons",
  "log",
  "tailwind_fuse",
@@ -2759,6 +2760,15 @@ dependencies = [
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "wasm_split_helpers",
+ "web-sys",
+]
+
+[[package]]
+name = "leptos-floating"
+version = "0.0.0"
+dependencies = [
+ "leptos",
+ "wasm-bindgen-test",
  "web-sys",
 ]
 

--- a/crates/floating/Cargo.toml
+++ b/crates/floating/Cargo.toml
@@ -1,0 +1,20 @@
+[package]
+name = "leptos-floating"
+version.workspace = true
+edition.workspace = true
+
+[dependencies]
+leptos = { workspace = true }
+web-sys = { version = "0.3.80", features = ["DomRect", "Element"] }
+
+[dev-dependencies]
+wasm-bindgen-test = { workspace = true }
+web-sys = { version = "0.3.80", features = [
+  "Document",
+  "HtmlButtonElement",
+  "HtmlDivElement",
+  "HtmlElement",
+  "CssStyleDeclaration",
+  "Window",
+  "Node",
+] }

--- a/crates/floating/src/lib.rs
+++ b/crates/floating/src/lib.rs
@@ -133,31 +133,35 @@ pub fn use_floating(
 /// Calculate the optimal position for a floating element
 pub fn calculate_position<T, U>(
     reference: &T,
-    _floating: &U,
+    floating: &U,
     options: FloatingOptions,
 ) -> Option<FloatingPosition>
 where
     T: AsRef<leptos::web_sys::HtmlElement>,
+    U: AsRef<leptos::web_sys::HtmlElement>,
 {
     use leptos::wasm_bindgen::JsCast;
     use leptos::web_sys::*;
 
     // Get the bounding rectangle of the reference element
     let reference_element: &HtmlElement = reference.as_ref();
-    let rect = reference_element
+    let ref_rect = reference_element
         .unchecked_ref::<Element>()
         .get_bounding_client_rect();
 
-    let reference_x = rect.left();
-    let reference_y = rect.top();
-    let reference_width = rect.width();
-    let reference_height = rect.height();
+    // Get the bounding rectangle of the floating element
+    let floating_element: &HtmlElement = floating.as_ref();
+    let float_rect = floating_element
+        .unchecked_ref::<Element>()
+        .get_bounding_client_rect();
 
     calculate_position_from_rect(
-        reference_x,
-        reference_y,
-        reference_width,
-        reference_height,
+        ref_rect.left(),
+        ref_rect.top(),
+        ref_rect.width(),
+        ref_rect.height(),
+        float_rect.width(),
+        float_rect.height(),
         options,
     )
 }
@@ -168,8 +172,13 @@ pub fn calculate_position_from_rect(
     reference_y: f64,
     reference_width: f64,
     reference_height: f64,
+    floating_width: f64,
+    floating_height: f64,
     options: FloatingOptions,
 ) -> Option<FloatingPosition> {
+    // Determine whether the cross-axis is horizontal (x) or vertical (y)
+    let is_horizontal_side = matches!(options.side, Side::Top | Side::Bottom);
+
     // Calculate base position based on side
     let (base_x, base_y) = match options.side {
         Side::Top => (reference_x, reference_y - options.side_offset),
@@ -184,9 +193,31 @@ pub fn calculate_position_from_rect(
         Side::Left => (reference_x - options.side_offset, reference_y),
     };
 
-    // Apply alignment offset (for now, just use the base position)
-    // TODO: Apply align offset based on floating element dimensions
-    let (x, y) = (base_x + options.align_offset, base_y);
+    // Calculate alignment shift on the cross-axis
+    let align_shift = match options.align {
+        Align::Start => 0.0,
+        Align::Center => {
+            if is_horizontal_side {
+                (reference_width - floating_width) / 2.0
+            } else {
+                (reference_height - floating_height) / 2.0
+            }
+        }
+        Align::End => {
+            if is_horizontal_side {
+                reference_width - floating_width
+            } else {
+                reference_height - floating_height
+            }
+        }
+    };
+
+    // Apply alignment shift and align_offset on the cross-axis
+    let (x, y) = if is_horizontal_side {
+        (base_x + align_shift + options.align_offset, base_y)
+    } else {
+        (base_x, base_y + align_shift + options.align_offset)
+    };
 
     Some(FloatingPosition {
         x,
@@ -225,25 +256,21 @@ mod tests {
 
     #[test]
     fn side_enum_all_variants() {
-        // Test Debug formatting
         assert_eq!(format!("{:?}", Side::Top), "Top");
         assert_eq!(format!("{:?}", Side::Right), "Right");
         assert_eq!(format!("{:?}", Side::Bottom), "Bottom");
         assert_eq!(format!("{:?}", Side::Left), "Left");
 
-        // Test equality
         assert_eq!(Side::Top, Side::Top);
         assert_ne!(Side::Top, Side::Bottom);
     }
 
     #[test]
     fn align_enum_all_variants() {
-        // Test Debug formatting
         assert_eq!(format!("{:?}", Align::Start), "Start");
         assert_eq!(format!("{:?}", Align::Center), "Center");
         assert_eq!(format!("{:?}", Align::End), "End");
 
-        // Test equality
         assert_eq!(Align::Start, Align::Start);
         assert_ne!(Align::Start, Align::Center);
     }
@@ -301,12 +328,11 @@ mod tests {
         assert_eq!(options.side, Side::Top);
         assert_eq!(options.align, Align::End);
         assert_eq!(options.side_offset, 16.0);
-        assert_eq!(options.align_offset, 0.0); // Should remain default
+        assert_eq!(options.align_offset, 0.0);
     }
 
     #[test]
     fn side_enum_exhaustive_match() {
-        // Ensures we handle all Side variants (will fail if new ones are added)
         let test_side = Side::Bottom;
         let result = match test_side {
             Side::Top => "top",
@@ -319,7 +345,6 @@ mod tests {
 
     #[test]
     fn align_enum_exhaustive_match() {
-        // Ensures we handle all Align variants (will fail if new ones are added)
         let test_align = Align::Center;
         let result = match test_align {
             Align::Start => "start",
@@ -331,7 +356,6 @@ mod tests {
 
     #[test]
     fn floating_options_negative_offsets() {
-        // Test that negative offsets are handled correctly
         let options = FloatingOptions {
             side: Side::Bottom,
             align: Align::Start,
@@ -381,11 +405,11 @@ mod tests {
             align_offset: 0.0,
         };
 
-        // Test with mock elements (we can't access DOM in unit tests)
-        let position = calculate_position_from_rect(100.0, 200.0, 120.0, 40.0, options).unwrap();
+        let position =
+            calculate_position_from_rect(100.0, 200.0, 120.0, 40.0, 80.0, 30.0, options).unwrap();
 
-        assert_eq!(position.x, 100.0); // reference_x
-        assert_eq!(position.y, 244.0); // reference_y (200) + height (40) + side_offset (4.0)
+        assert_eq!(position.x, 100.0);
+        assert_eq!(position.y, 244.0);
         assert_eq!(position.side, Side::Bottom);
         assert_eq!(position.align, Align::Start);
     }
@@ -394,34 +418,34 @@ mod tests {
     fn calculate_position_top_side() {
         let options = FloatingOptions {
             side: Side::Top,
-            align: Align::Center,
+            align: Align::Start,
             side_offset: 8.0,
             align_offset: 0.0,
         };
 
-        let position = calculate_position_from_rect(100.0, 200.0, 120.0, 40.0, options).unwrap();
+        let position =
+            calculate_position_from_rect(100.0, 200.0, 120.0, 40.0, 80.0, 30.0, options).unwrap();
 
-        assert_eq!(position.x, 100.0); // reference_x
-        assert_eq!(position.y, 192.0); // reference_y (200) - side_offset (8.0)
+        assert_eq!(position.x, 100.0);
+        assert_eq!(position.y, 192.0);
         assert_eq!(position.side, Side::Top);
-        assert_eq!(position.align, Align::Center);
     }
 
     #[test]
     fn calculate_position_right_side() {
         let options = FloatingOptions {
             side: Side::Right,
-            align: Align::End,
+            align: Align::Start,
             side_offset: 12.0,
             align_offset: 0.0,
         };
 
-        let position = calculate_position_from_rect(100.0, 200.0, 120.0, 40.0, options).unwrap();
+        let position =
+            calculate_position_from_rect(100.0, 200.0, 120.0, 40.0, 80.0, 30.0, options).unwrap();
 
-        assert_eq!(position.x, 232.0); // reference_x (100) + width (120) + side_offset (12.0)
-        assert_eq!(position.y, 200.0); // reference_y
+        assert_eq!(position.x, 232.0);
+        assert_eq!(position.y, 200.0);
         assert_eq!(position.side, Side::Right);
-        assert_eq!(position.align, Align::End);
     }
 
     #[test]
@@ -433,12 +457,12 @@ mod tests {
             align_offset: 0.0,
         };
 
-        let position = calculate_position_from_rect(100.0, 200.0, 120.0, 40.0, options).unwrap();
+        let position =
+            calculate_position_from_rect(100.0, 200.0, 120.0, 40.0, 80.0, 30.0, options).unwrap();
 
-        assert_eq!(position.x, 94.0); // reference_x (100) - side_offset (6.0)
-        assert_eq!(position.y, 200.0); // reference_y
+        assert_eq!(position.x, 94.0);
+        assert_eq!(position.y, 200.0);
         assert_eq!(position.side, Side::Left);
-        assert_eq!(position.align, Align::Start);
     }
 
     #[test]
@@ -450,10 +474,11 @@ mod tests {
             align_offset: 0.0,
         };
 
-        let position = calculate_position_from_rect(100.0, 200.0, 120.0, 40.0, options).unwrap();
+        let position =
+            calculate_position_from_rect(100.0, 200.0, 120.0, 40.0, 80.0, 30.0, options).unwrap();
 
-        assert_eq!(position.x, 100.0); // reference_x
-        assert_eq!(position.y, 240.0); // reference_y (200) + height (40) + side_offset (0.0)
+        assert_eq!(position.x, 100.0);
+        assert_eq!(position.y, 240.0);
     }
 
     #[test]
@@ -461,14 +486,15 @@ mod tests {
         let options = FloatingOptions {
             side: Side::Top,
             align: Align::Start,
-            side_offset: -10.0, // Negative offset
+            side_offset: -10.0,
             align_offset: 0.0,
         };
 
-        let position = calculate_position_from_rect(100.0, 200.0, 120.0, 40.0, options).unwrap();
+        let position =
+            calculate_position_from_rect(100.0, 200.0, 120.0, 40.0, 80.0, 30.0, options).unwrap();
 
-        assert_eq!(position.x, 100.0); // reference_x
-        assert_eq!(position.y, 210.0); // reference_y (200) - side_offset (-10.0) = 200 - (-10) = 210
+        assert_eq!(position.x, 100.0);
+        assert_eq!(position.y, 210.0);
     }
 
     #[test]
@@ -476,63 +502,14 @@ mod tests {
         let options = FloatingOptions {
             side: Side::Right,
             align: Align::Start,
-            side_offset: 1000.0, // Large offset
+            side_offset: 1000.0,
             align_offset: 0.0,
         };
 
-        let position = calculate_position_from_rect(100.0, 200.0, 120.0, 40.0, options).unwrap();
+        let position =
+            calculate_position_from_rect(100.0, 200.0, 120.0, 40.0, 80.0, 30.0, options).unwrap();
 
-        assert_eq!(position.x, 1220.0); // reference_x (100) + width (120) + side_offset (1000.0)
-        assert_eq!(position.y, 200.0); // reference_y
-    }
-
-    #[test]
-    fn floating_position_all_combinations() {
-        // Test all side/align combinations to ensure comprehensive coverage
-        let sides = [Side::Top, Side::Right, Side::Bottom, Side::Left];
-        let aligns = [Align::Start, Align::Center, Align::End];
-
-        for side in sides.iter() {
-            for align in aligns.iter() {
-                let options = FloatingOptions {
-                    side: *side,
-                    align: *align,
-                    side_offset: 10.0,
-                    align_offset: 5.0,
-                };
-
-                let position = calculate_position_from_rect(100.0, 200.0, 120.0, 40.0, options);
-                assert!(
-                    position.is_some(),
-                    "Position calculation should succeed for side {:?} and align {:?}",
-                    side,
-                    align
-                );
-
-                let pos = position.unwrap();
-                assert_eq!(pos.side, *side);
-                assert_eq!(pos.align, *align);
-
-                // Verify positioning logic for each side (align_offset 5.0 is added to x for all sides currently)
-                match side {
-                    Side::Top => {
-                        assert_eq!(pos.x, 105.0); // reference_x (100) + align_offset (5.0)
-                        assert_eq!(pos.y, 190.0); // reference_y (200) - side_offset (10.0)
-                    }
-                    Side::Bottom => {
-                        assert_eq!(pos.x, 105.0); // reference_x (100) + align_offset (5.0)
-                        assert_eq!(pos.y, 250.0); // reference_y (200) + height (40) + side_offset (10.0)
-                    }
-                    Side::Right => {
-                        assert_eq!(pos.x, 235.0); // reference_x (100) + width (120) + side_offset (10.0) + align_offset (5.0)
-                        assert_eq!(pos.y, 200.0); // reference_y (200)
-                    }
-                    Side::Left => {
-                        assert_eq!(pos.x, 95.0); // reference_x (100) - side_offset (10.0) + align_offset (5.0)
-                        assert_eq!(pos.y, 200.0); // reference_y (200)
-                    }
-                }
-            }
-        }
+        assert_eq!(position.x, 1220.0);
+        assert_eq!(position.y, 200.0);
     }
 }

--- a/crates/floating/tests/floating_dom_integration.rs
+++ b/crates/floating/tests/floating_dom_integration.rs
@@ -1,4 +1,4 @@
-use holt_kit::floating::*;
+use leptos_floating::*;
 use wasm_bindgen_test::*;
 
 wasm_bindgen_test_configure!(run_in_browser);
@@ -82,7 +82,9 @@ fn test_calculate_position_from_rect_in_browser() {
         align_offset: 0.0,
     };
 
-    let position = calculate_position_from_rect(100.0, 200.0, 120.0, 40.0, options).unwrap();
+    // floating_width=80, floating_height=30 (not used for Align::Start)
+    let position =
+        calculate_position_from_rect(100.0, 200.0, 120.0, 40.0, 80.0, 30.0, options).unwrap();
 
     assert_eq!(position.x, 100.0); // reference_x
     assert_eq!(position.y, 244.0); // reference_y + height + side_offset

--- a/crates/floating/tests/positioning.rs
+++ b/crates/floating/tests/positioning.rs
@@ -1,0 +1,264 @@
+use leptos_floating::*;
+
+// --- align_offset cross-axis tests ---
+
+#[test]
+fn align_offset_shifts_x_for_top_side() {
+    // For Top/Bottom sides, the cross-axis is X, so align_offset should shift X
+    let options = FloatingOptions {
+        side: Side::Top,
+        align: Align::Start,
+        side_offset: 0.0,
+        align_offset: 10.0,
+    };
+
+    let pos = calculate_position_from_rect(100.0, 200.0, 120.0, 40.0, 80.0, 30.0, options).unwrap();
+
+    assert_eq!(pos.x, 110.0, "align_offset should shift x for Top side");
+    assert_eq!(pos.y, 200.0, "align_offset should NOT shift y for Top side");
+}
+
+#[test]
+fn align_offset_shifts_x_for_bottom_side() {
+    let options = FloatingOptions {
+        side: Side::Bottom,
+        align: Align::Start,
+        side_offset: 0.0,
+        align_offset: 10.0,
+    };
+
+    let pos = calculate_position_from_rect(100.0, 200.0, 120.0, 40.0, 80.0, 30.0, options).unwrap();
+
+    assert_eq!(pos.x, 110.0, "align_offset should shift x for Bottom side");
+    assert_eq!(
+        pos.y, 240.0,
+        "align_offset should NOT shift y for Bottom side"
+    );
+}
+
+#[test]
+fn align_offset_shifts_y_for_left_side() {
+    // For Left/Right sides, the cross-axis is Y, so align_offset should shift Y
+    let options = FloatingOptions {
+        side: Side::Left,
+        align: Align::Start,
+        side_offset: 0.0,
+        align_offset: 10.0,
+    };
+
+    let pos = calculate_position_from_rect(100.0, 200.0, 120.0, 40.0, 80.0, 30.0, options).unwrap();
+
+    assert_eq!(
+        pos.x, 100.0,
+        "align_offset should NOT shift x for Left side"
+    );
+    assert_eq!(pos.y, 210.0, "align_offset should shift y for Left side");
+}
+
+#[test]
+fn align_offset_shifts_y_for_right_side() {
+    let options = FloatingOptions {
+        side: Side::Right,
+        align: Align::Start,
+        side_offset: 0.0,
+        align_offset: 10.0,
+    };
+
+    let pos = calculate_position_from_rect(100.0, 200.0, 120.0, 40.0, 80.0, 30.0, options).unwrap();
+
+    assert_eq!(
+        pos.x, 220.0,
+        "align_offset should NOT shift x for Right side"
+    );
+    assert_eq!(pos.y, 210.0, "align_offset should shift y for Right side");
+}
+
+// --- Align::Center tests ---
+
+#[test]
+fn align_center_centers_on_bottom_side() {
+    // reference_width=120, floating_width=80
+    // Center offset = (120 - 80) / 2 = 20
+    let options = FloatingOptions {
+        side: Side::Bottom,
+        align: Align::Center,
+        side_offset: 0.0,
+        align_offset: 0.0,
+    };
+
+    let pos = calculate_position_from_rect(100.0, 200.0, 120.0, 40.0, 80.0, 30.0, options).unwrap();
+
+    assert_eq!(
+        pos.x, 120.0,
+        "Center align should center floating on reference (100 + 20)"
+    );
+    assert_eq!(pos.y, 240.0);
+}
+
+#[test]
+fn align_center_centers_on_top_side() {
+    let options = FloatingOptions {
+        side: Side::Top,
+        align: Align::Center,
+        side_offset: 0.0,
+        align_offset: 0.0,
+    };
+
+    let pos = calculate_position_from_rect(100.0, 200.0, 120.0, 40.0, 80.0, 30.0, options).unwrap();
+
+    assert_eq!(
+        pos.x, 120.0,
+        "Center align should center floating on reference (100 + (120-80)/2)"
+    );
+    assert_eq!(pos.y, 200.0);
+}
+
+#[test]
+fn align_center_centers_on_right_side() {
+    // reference_height=40, floating_height=30
+    // Center offset = (40 - 30) / 2 = 5
+    let options = FloatingOptions {
+        side: Side::Right,
+        align: Align::Center,
+        side_offset: 0.0,
+        align_offset: 0.0,
+    };
+
+    let pos = calculate_position_from_rect(100.0, 200.0, 120.0, 40.0, 80.0, 30.0, options).unwrap();
+
+    assert_eq!(pos.x, 220.0);
+    assert_eq!(
+        pos.y, 205.0,
+        "Center align should center floating on reference (200 + (40-30)/2)"
+    );
+}
+
+#[test]
+fn align_center_centers_on_left_side() {
+    let options = FloatingOptions {
+        side: Side::Left,
+        align: Align::Center,
+        side_offset: 0.0,
+        align_offset: 0.0,
+    };
+
+    let pos = calculate_position_from_rect(100.0, 200.0, 120.0, 40.0, 80.0, 30.0, options).unwrap();
+
+    assert_eq!(pos.x, 100.0);
+    assert_eq!(
+        pos.y, 205.0,
+        "Center align should center floating on reference (200 + (40-30)/2)"
+    );
+}
+
+// --- Align::End tests ---
+
+#[test]
+fn align_end_aligns_on_bottom_side() {
+    // reference_width=120, floating_width=80
+    // End offset = 120 - 80 = 40
+    let options = FloatingOptions {
+        side: Side::Bottom,
+        align: Align::End,
+        side_offset: 0.0,
+        align_offset: 0.0,
+    };
+
+    let pos = calculate_position_from_rect(100.0, 200.0, 120.0, 40.0, 80.0, 30.0, options).unwrap();
+
+    assert_eq!(
+        pos.x, 140.0,
+        "End align should align floating to end of reference (100 + 120 - 80)"
+    );
+    assert_eq!(pos.y, 240.0);
+}
+
+#[test]
+fn align_end_aligns_on_top_side() {
+    let options = FloatingOptions {
+        side: Side::Top,
+        align: Align::End,
+        side_offset: 0.0,
+        align_offset: 0.0,
+    };
+
+    let pos = calculate_position_from_rect(100.0, 200.0, 120.0, 40.0, 80.0, 30.0, options).unwrap();
+
+    assert_eq!(
+        pos.x, 140.0,
+        "End align should align floating to end of reference (100 + 120 - 80)"
+    );
+    assert_eq!(pos.y, 200.0);
+}
+
+#[test]
+fn align_end_aligns_on_right_side() {
+    // reference_height=40, floating_height=30
+    // End offset = 40 - 30 = 10
+    let options = FloatingOptions {
+        side: Side::Right,
+        align: Align::End,
+        side_offset: 0.0,
+        align_offset: 0.0,
+    };
+
+    let pos = calculate_position_from_rect(100.0, 200.0, 120.0, 40.0, 80.0, 30.0, options).unwrap();
+
+    assert_eq!(pos.x, 220.0);
+    assert_eq!(
+        pos.y, 210.0,
+        "End align should align floating to end of reference (200 + 40 - 30)"
+    );
+}
+
+#[test]
+fn align_end_aligns_on_left_side() {
+    let options = FloatingOptions {
+        side: Side::Left,
+        align: Align::End,
+        side_offset: 0.0,
+        align_offset: 0.0,
+    };
+
+    let pos = calculate_position_from_rect(100.0, 200.0, 120.0, 40.0, 80.0, 30.0, options).unwrap();
+
+    assert_eq!(pos.x, 100.0);
+    assert_eq!(
+        pos.y, 210.0,
+        "End align should align floating to end of reference (200 + 40 - 30)"
+    );
+}
+
+// --- Combined: Align + align_offset ---
+
+#[test]
+fn align_center_with_align_offset_on_bottom() {
+    let options = FloatingOptions {
+        side: Side::Bottom,
+        align: Align::Center,
+        side_offset: 0.0,
+        align_offset: 5.0,
+    };
+
+    let pos = calculate_position_from_rect(100.0, 200.0, 120.0, 40.0, 80.0, 30.0, options).unwrap();
+
+    // Center: 100 + (120-80)/2 = 120, then + align_offset 5 = 125
+    assert_eq!(pos.x, 125.0);
+    assert_eq!(pos.y, 240.0);
+}
+
+#[test]
+fn align_end_with_align_offset_on_right() {
+    let options = FloatingOptions {
+        side: Side::Right,
+        align: Align::End,
+        side_offset: 0.0,
+        align_offset: 5.0,
+    };
+
+    let pos = calculate_position_from_rect(100.0, 200.0, 120.0, 40.0, 80.0, 30.0, options).unwrap();
+
+    // End: 200 + 40 - 30 = 210, then + align_offset 5 = 215
+    assert_eq!(pos.x, 220.0);
+    assert_eq!(pos.y, 215.0);
+}

--- a/crates/floating/tests/simple_floating_integration.rs
+++ b/crates/floating/tests/simple_floating_integration.rs
@@ -1,4 +1,4 @@
-use holt_kit::floating::*;
+use leptos_floating::*;
 use wasm_bindgen_test::*;
 
 wasm_bindgen_test_configure!(run_in_browser);

--- a/crates/kit/Cargo.toml
+++ b/crates/kit/Cargo.toml
@@ -6,6 +6,7 @@ edition.workspace = true
 
 [dependencies]
 leptos = { workspace = true }
+leptos-floating = { path = "../floating" }
 tailwind_fuse = { version = "0.3.0", features = ["variant"] }
 leptos_icons = "0.7.0"
 icondata = { version = "0.7.0", default-features = false, features = [

--- a/crates/kit/src/CLAUDE.md
+++ b/crates/kit/src/CLAUDE.md
@@ -7,7 +7,8 @@ visual components add styling.
 
 - **`behavior/`** - State management and interactions (Leptos primitives)
 - **`visual/`** - Tailwind styling wrappers
-- **`floating.rs`** - Positioning for dropdowns, tooltips, popovers
+- **`leptos-floating`** (external crate) - Positioning for dropdowns, tooltips,
+  popovers
 
 ## Development Pattern
 

--- a/crates/kit/src/behavior/select.rs
+++ b/crates/kit/src/behavior/select.rs
@@ -1,7 +1,7 @@
-use crate::floating::{Align, FloatingOptions, Side, use_floating};
 use leptos::html::Div;
 use leptos::portal::Portal;
 use leptos::prelude::*;
+use leptos_floating::{Align, FloatingOptions, Side, use_floating};
 
 /// Select behavior context that manages state and interactions
 #[derive(Clone)]

--- a/crates/kit/src/lib.rs
+++ b/crates/kit/src/lib.rs
@@ -1,3 +1,2 @@
 pub mod behavior;
-pub mod floating;
 pub mod visual;

--- a/crates/kit/src/visual/select.rs
+++ b/crates/kit/src/visual/select.rs
@@ -7,7 +7,7 @@ use crate::behavior::{
     SelectRoot as SelectRootPrimitive, SelectTrigger as SelectTriggerPrimitive,
     SelectValue as SelectValuePrimitive,
 };
-use crate::floating::{Align, Side};
+use leptos_floating::{Align, Side};
 
 /// The main Select component
 #[component]


### PR DESCRIPTION
## Summary
- Extracts `floating.rs` from `holt-kit` into a standalone `leptos-floating` crate
- Fixes `align_offset` bug: now correctly applies to the cross-axis (x for Top/Bottom, y for Left/Right)
- Implements `Align::Center` and `Align::End` positioning using floating element dimensions
- Adds `floating_width`/`floating_height` params to `calculate_position_from_rect`
- Updates all internal imports to use `leptos_floating::*` directly

Closes #376

## Test plan
- [x] 14 new positioning tests (cross-axis offset, center alignment, end alignment, combined)
- [x] All 35 leptos-floating tests pass (21 unit + 14 integration)
- [x] `just format-rust true && just lint-rust && just test-rust` pass
- [x] Pre-commit hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)