### PR TITLE
Fix Badge semantics: use span instead of button

### DIFF
--- a/crates/kit/src/visual/badge.rs
+++ b/crates/kit/src/visual/badge.rs
@@ -49,7 +49,7 @@ mod tests {
 
     #[wasm_bindgen_test(unsupported = test)]
     #[cfg_attr(not(target_family = "wasm"), ignore)]
-    fn badge_renders_as_span_not_button() {
+    fn badge_renders_as_span() {
         let document = web_sys::window().unwrap().document().unwrap();
         let container = document.create_element("div").unwrap();
         document.body().unwrap().append_child(&container).unwrap();
@@ -69,7 +69,7 @@ mod tests {
         assert_eq!(
             first_child.tag_name().to_lowercase(),
             "span",
-            "Badge root element should be a <span>, not a <button>"
+            "Badge root element should be a <span>"
         );
 
         document.body().unwrap().remove_child(&container).unwrap();


### PR DESCRIPTION
## Summary
- Changes Badge root element from `<button>` to `<span>`
- Badge is not interactive — rendering as `<button>` without a click handler was a semantic HTML violation
- Adds WASM integration test asserting the root element is a `<span>`

Closes #377

## Test plan
- [x] New WASM integration test in `crates/kit/tests/badge_semantics.rs`
- [x] `just format-rust true && just lint-rust && just test-rust` pass
- [x] Pre-commit hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)