### PR TITLE
Add missing stories for separator and typography

### DIFF
--- a/crates/kit-docs/src/stories.rs
+++ b/crates/kit-docs/src/stories.rs
@@ -7,6 +7,8 @@ mod collapsible;
 mod input;
 mod label;
 mod select;
+mod separator;
 mod switch;
 mod textarea;
 mod toggle;
+mod typography;

--- a/crates/kit-docs/src/stories/separator.rs
+++ b/crates/kit-docs/src/stories/separator.rs
@@ -1,0 +1,43 @@
+// @component Separator
+use holt_book::{story, variant};
+use holt_kit::visual::{Orientation, Separator};
+use leptos::prelude::*;
+
+#[variant]
+fn default() -> AnyView {
+    view! {
+        <div class="space-y-1">
+            <h4 class="text-sm font-medium leading-none">"Holt UI"</h4>
+            <p class="text-sm text-muted-foreground">"An open-source UI component library."</p>
+        </div>
+        <Separator class="my-4" />
+        <div class="flex h-5 items-center space-x-4 text-sm">
+            <div>"Docs"</div>
+            <Separator orientation=Orientation::Vertical />
+            <div>"Source"</div>
+            <Separator orientation=Orientation::Vertical />
+            <div>"Blog"</div>
+        </div>
+    }
+    .into_any()
+}
+
+#[variant]
+fn vertical() -> AnyView {
+    view! {
+        <div class="flex h-5 items-center space-x-4 text-sm">
+            <div>"Home"</div>
+            <Separator orientation=Orientation::Vertical />
+            <div>"About"</div>
+            <Separator orientation=Orientation::Vertical />
+            <div>"Contact"</div>
+        </div>
+    }
+    .into_any()
+}
+
+include!(concat!(env!("OUT_DIR"), "/stories/separator_source.rs"));
+
+#[story(id = "separator", name = "Separator", extra_docs = SEPARATOR_SOURCE)]
+/// A visual divider to separate content
+const SEPARATOR_STORY: () = &[default, vertical];

--- a/crates/kit-docs/src/stories/typography.rs
+++ b/crates/kit-docs/src/stories/typography.rs
@@ -1,0 +1,43 @@
+// @component Typography
+use holt_book::{story, variant};
+use holt_kit::visual::{Blockquote, H1, H2, H3, H4, Large, Lead, Muted, P, Small};
+use leptos::prelude::*;
+
+#[variant]
+fn headings() -> AnyView {
+    view! {
+        <div class="space-y-4">
+            <H1>"This is H1"</H1>
+            <H2>"This is H2"</H2>
+            <H3>"This is H3"</H3>
+            <H4>"This is H4"</H4>
+        </div>
+    }
+    .into_any()
+}
+
+#[variant]
+fn body_text() -> AnyView {
+    view! {
+        <div class="space-y-4">
+            <P>"This is a paragraph. The quick brown fox jumps over the lazy dog."</P>
+            <Lead>"This is lead text."</Lead>
+            <Large>"This is large text."</Large>
+            <Small>"This is small text."</Small>
+            <Muted>"This is muted text."</Muted>
+        </div>
+    }
+    .into_any()
+}
+
+#[variant]
+fn blockquote() -> AnyView {
+    view! { <Blockquote>"After all, everyone enjoys a good quote now and then."</Blockquote> }
+        .into_any()
+}
+
+include!(concat!(env!("OUT_DIR"), "/stories/typography_source.rs"));
+
+#[story(id = "typography", name = "Typography", extra_docs = TYPOGRAPHY_SOURCE)]
+/// Typography components for consistent text styling
+const TYPOGRAPHY_STORY: () = &[headings, body_text, blockquote];


### PR DESCRIPTION
## Summary
- Adds separator story with 2 variants: horizontal (default) and vertical
- Adds typography story with 3 variants: headings (H1-H4), body_text (P, Lead, Large, Small, Muted), blockquote
- Registers both in `stories.rs`

Closes #380
Refs #26, #28

## Test plan
- [x] `just format-rust true && just lint-rust && just test-rust` pass
- [x] Pre-commit hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)