### PR TITLE
Fix docs workflow cancelling unrelated PR runs

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -21,7 +21,7 @@ on:
   workflow_dispatch:
 
 concurrency:
-  group: "pages"
+  group: "pages-${{ github.ref }}"
   cancel-in-progress: true
 
 permissions:


### PR DESCRIPTION
## Summary
- Scopes the docs workflow concurrency group from static `"pages"` to `"pages-${{ github.ref }}"`
- Previously, any PR touching docs/kit paths would cancel in-progress runs from other PRs
- Now PRs only cancel their own previous runs, and main deploys only cancel other main deploys

## Test plan
- [x] Verify concurrent PR CI runs no longer get cancelled by each other

🤖 Generated with [Claude Code](https://claude.com/claude-code)