### PR TITLE
Add Dockerfile for kit-docs storybook

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,13 @@
+target/
+dist/
+node_modules/
+.git/
+.bin/
+.prettiercache
+.idea/
+.playwright-mcp/
+planning/
+result
+*.pdb
+**/*.rs.bk
+**/tests/visual-baselines/

--- a/.markdownlintignore
+++ b/.markdownlintignore
@@ -1,1 +1,2 @@
 target/
+planning/

--- a/crates/kit-docs/Dockerfile
+++ b/crates/kit-docs/Dockerfile
@@ -1,0 +1,33 @@
+# syntax=docker/dockerfile:1
+
+# ---------------------------------------------------------------------------
+# Stage 1 – Build the kit-docs WASM app with Trunk
+# ---------------------------------------------------------------------------
+FROM rust:1.93-bookworm AS builder
+
+# Install wasm target
+RUN rustup target add wasm32-unknown-unknown
+
+# Install trunk (WASM bundler)
+RUN cargo install trunk --locked
+
+WORKDIR /app
+
+# Copy the full workspace (inter-crate deps require it)
+COPY Cargo.toml rust-toolchain.toml ./
+COPY crates/ crates/
+
+# Build kit-docs in release mode from its directory
+WORKDIR /app/crates/kit-docs
+RUN trunk build --release
+
+# ---------------------------------------------------------------------------
+# Stage 2 – Serve with Caddy (SPA fallback via --try-files, no config file)
+# ---------------------------------------------------------------------------
+FROM caddy:alpine
+
+COPY --from=builder /app/crates/kit-docs/dist/ /srv/
+
+EXPOSE 80
+
+CMD ["caddy", "file-server", "--root", "/srv", "--listen", ":80", "--try-files", "{path}", "/index.html"]

--- a/crates/kit-docs/justfile
+++ b/crates/kit-docs/justfile
@@ -72,3 +72,7 @@ build-hydrate:
 # just kit-docs render-variant select 2 ./output.png
 render-variant story_id variant output_path="./variant.png":
     cargo run --bin render-variant --features visual-regression -- {{ story_id }} {{ variant }} {{ absolute_path(invocation_directory() / output_path) }}
+
+# Build the kit-docs Docker image for E2E testing
+docker-build tag="holt-kit-docs":
+    docker build -t {{ tag }} -f Dockerfile ../..


### PR DESCRIPTION
Multi-stage Docker build for the kit-docs storybook app, needed for doco-based E2E and visual regression testing. The builder stage compiles the WASM app with trunk, and the runtime stage serves it from `caddy:alpine` with SPA fallback so client-side routes like `/visual-test/{story_id}/{variant_index}` work correctly.

Also adds a `.dockerignore` at the workspace root to keep the build context lean, and a `just kit-docs docker-build` recipe.

🤖 Generated with [Claude Code](https://claude.com/claude-code)