### PR TITLE
Upgrade flox env and fix CI workflow hygiene

### DIFF
--- a/.flox/env/manifest.lock
+++ b/.flox/env/manifest.lock
@@ -101,27 +101,27 @@
     {
       "attr_path": "rust-analyzer",
       "broken": false,
-      "derivation": "/nix/store/ika6vzi2dc4n3q3hmxksb3nyrwnv1rgw-rust-analyzer-2025-08-25.drv",
-      "description": "Modular compiler frontend for the Rust language",
+      "derivation": "/nix/store/92hm5hc3nhjxr3b16dj8gmzjnaiq4cpn-rust-analyzer-2026-02-16.drv",
+      "description": "Language server for the Rust language",
       "install_id": "rust-analyzer",
       "license": "[ MIT, Apache-2.0 ]",
-      "locked_url": "https://github.com/flox/nixpkgs?rev=554be6495561ff07b6c724047bdd7e0716aa7b46",
-      "name": "rust-analyzer-2025-08-25",
+      "locked_url": "https://github.com/flox/nixpkgs?rev=aca4d95fce4914b3892661bcb80b8087293536c6",
+      "name": "rust-analyzer-2026-02-16",
       "pname": "rust-analyzer",
-      "rev": "554be6495561ff07b6c724047bdd7e0716aa7b46",
-      "rev_count": 864611,
-      "rev_date": "2025-09-21T03:59:47Z",
-      "scrape_date": "2025-09-24T03:00:12.001835Z",
+      "rev": "aca4d95fce4914b3892661bcb80b8087293536c6",
+      "rev_count": 958961,
+      "rev_date": "2026-03-06T04:56:59Z",
+      "scrape_date": "2026-03-08T04:48:13.221976Z",
       "stabilities": [
         "unstable"
       ],
       "unfree": false,
-      "version": "2025-08-25",
+      "version": "2026-02-16",
       "outputs_to_install": [
         "out"
       ],
       "outputs": {
-        "out": "/nix/store/i4j351dsjw9jprb6aavfx6h9f56r42mv-rust-analyzer-2025-08-25"
+        "out": "/nix/store/nz6l7l5kgf7dmgiq35b3pr00smcd39aj-rust-analyzer-2026-02-16"
       },
       "system": "aarch64-darwin",
       "group": "rust-analyzer",
@@ -130,27 +130,27 @@
     {
       "attr_path": "rust-analyzer",
       "broken": false,
-      "derivation": "/nix/store/dw1hz2s9z2pqa15bdl35p6w21mlyvndi-rust-analyzer-2025-08-25.drv",
-      "description": "Modular compiler frontend for the Rust language",
+      "derivation": "/nix/store/6qa81n8a8r6axy20y3rb77x7xd134k1j-rust-analyzer-2026-02-16.drv",
+      "description": "Language server for the Rust language",
       "install_id": "rust-analyzer",
       "license": "[ MIT, Apache-2.0 ]",
-      "locked_url": "https://github.com/flox/nixpkgs?rev=554be6495561ff07b6c724047bdd7e0716aa7b46",
-      "name": "rust-analyzer-2025-08-25",
+      "locked_url": "https://github.com/flox/nixpkgs?rev=aca4d95fce4914b3892661bcb80b8087293536c6",
+      "name": "rust-analyzer-2026-02-16",
       "pname": "rust-analyzer",
-      "rev": "554be6495561ff07b6c724047bdd7e0716aa7b46",
-      "rev_count": 864611,
-      "rev_date": "2025-09-21T03:59:47Z",
-      "scrape_date": "2025-09-24T03:29:49.238895Z",
+      "rev": "aca4d95fce4914b3892661bcb80b8087293536c6",
+      "rev_count": 958961,
+      "rev_date": "2026-03-06T04:56:59Z",
+      "scrape_date": "2026-03-08T05:25:28.862251Z",
       "stabilities": [
         "unstable"
       ],
       "unfree": false,
-      "version": "2025-08-25",
+      "version": "2026-02-16",
       "outputs_to_install": [
         "out"
       ],
       "outputs": {
-        "out": "/nix/store/gjjn5pcnsd5vkh8p8rzdjbwlhaj9prz0-rust-analyzer-2025-08-25"
+        "out": "/nix/store/8wl18z22vf7y7kj77k4a3y4a63kzrlpq-rust-analyzer-2026-02-16"
       },
       "system": "aarch64-linux",
       "group": "rust-analyzer",
@@ -159,27 +159,27 @@
     {
       "attr_path": "rust-analyzer",
       "broken": false,
-      "derivation": "/nix/store/y6g4nnzparx8cm4gb8r6igrsla3z69g0-rust-analyzer-2025-08-25.drv",
-      "description": "Modular compiler frontend for the Rust language",
+      "derivation": "/nix/store/zk5884n3nn8jrjiiyvh501d8lhlzf5fn-rust-analyzer-2026-02-16.drv",
+      "description": "Language server for the Rust language",
       "install_id": "rust-analyzer",
       "license": "[ MIT, Apache-2.0 ]",
-      "locked_url": "https://github.com/flox/nixpkgs?rev=554be6495561ff07b6c724047bdd7e0716aa7b46",
-      "name": "rust-analyzer-2025-08-25",
+      "locked_url": "https://github.com/flox/nixpkgs?rev=aca4d95fce4914b3892661bcb80b8087293536c6",
+      "name": "rust-analyzer-2026-02-16",
       "pname": "rust-analyzer",
-      "rev": "554be6495561ff07b6c724047bdd7e0716aa7b46",
-      "rev_count": 864611,
-      "rev_date": "2025-09-21T03:59:47Z",
-      "scrape_date": "2025-09-24T03:57:00.351192Z",
+      "rev": "aca4d95fce4914b3892661bcb80b8087293536c6",
+      "rev_count": 958961,
+      "rev_date": "2026-03-06T04:56:59Z",
+      "scrape_date": "2026-03-08T06:05:16.771775Z",
       "stabilities": [
         "unstable"
       ],
       "unfree": false,
-      "version": "2025-08-25",
+      "version": "2026-02-16",
       "outputs_to_install": [
         "out"
       ],
       "outputs": {
-        "out": "/nix/store/3cgw8w8xqf626h9bkcwawwnqbggbmxj3-rust-analyzer-2025-08-25"
+        "out": "/nix/store/7zxbyg0cr4ajg1cnfdfahwhl37jl5jdg-rust-analyzer-2026-02-16"
       },
       "system": "x86_64-darwin",
       "group": "rust-analyzer",
@@ -188,27 +188,27 @@
     {
       "attr_path": "rust-analyzer",
       "broken": false,
-      "derivation": "/nix/store/wh4vsg3idkzi7vy4059xfxsjjsaj49l2-rust-analyzer-2025-08-25.drv",
-      "description": "Modular compiler frontend for the Rust language",
+      "derivation": "/nix/store/99x04i2p88f4hjy3jzaz0xflf2837zfp-rust-analyzer-2026-02-16.drv",
+      "description": "Language server for the Rust language",
       "install_id": "rust-analyzer",
       "license": "[ MIT, Apache-2.0 ]",
-      "locked_url": "https://github.com/flox/nixpkgs?rev=554be6495561ff07b6c724047bdd7e0716aa7b46",
-      "name": "rust-analyzer-2025-08-25",
+      "locked_url": "https://github.com/flox/nixpkgs?rev=aca4d95fce4914b3892661bcb80b8087293536c6",
+      "name": "rust-analyzer-2026-02-16",
       "pname": "rust-analyzer",
-      "rev": "554be6495561ff07b6c724047bdd7e0716aa7b46",
-      "rev_count": 864611,
-      "rev_date": "2025-09-21T03:59:47Z",
-      "scrape_date": "2025-09-24T04:28:55.338932Z",
+      "rev": "aca4d95fce4914b3892661bcb80b8087293536c6",
+      "rev_count": 958961,
+      "rev_date": "2026-03-06T04:56:59Z",
+      "scrape_date": "2026-03-08T06:48:53.930913Z",
       "stabilities": [
         "unstable"
       ],
       "unfree": false,
-      "version": "2025-08-25",
+      "version": "2026-02-16",
       "outputs_to_install": [
         "out"
       ],
       "outputs": {
-        "out": "/nix/store/13irk3d1x0qihfhz2c1jv3d170p9sbnc-rust-analyzer-2025-08-25"
+        "out": "/nix/store/3h49id8siw8mlpkk47n8bxbkhiqwwc15-rust-analyzer-2026-02-16"
       },
       "system": "x86_64-linux",
       "group": "rust-analyzer",
@@ -217,27 +217,27 @@
     {
       "attr_path": "cargo",
       "broken": false,
-      "derivation": "/nix/store/28svwyswzdaj5icqiyyrcgzn84ylxc11-cargo-1.89.0.drv",
+      "derivation": "/nix/store/15wbksir8wlxr7lbjbyycp2wcm7mgm7z-cargo-1.93.0.drv",
       "description": "Downloads your Rust project's dependencies and builds your project",
       "install_id": "cargo",
       "license": "[ MIT, Apache-2.0 ]",
-      "locked_url": "https://github.com/flox/nixpkgs?rev=554be6495561ff07b6c724047bdd7e0716aa7b46",
-      "name": "cargo-1.89.0",
+      "locked_url": "https://github.com/flox/nixpkgs?rev=aca4d95fce4914b3892661bcb80b8087293536c6",
+      "name": "cargo-1.93.0",
       "pname": "cargo",
-      "rev": "554be6495561ff07b6c724047bdd7e0716aa7b46",
-      "rev_count": 864611,
-      "rev_date": "2025-09-21T03:59:47Z",
-      "scrape_date": "2025-09-24T02:58:44.654960Z",
+      "rev": "aca4d95fce4914b3892661bcb80b8087293536c6",
+      "rev_count": 958961,
+      "rev_date": "2026-03-06T04:56:59Z",
+      "scrape_date": "2026-03-08T04:46:43.131888Z",
       "stabilities": [
         "unstable"
       ],
       "unfree": false,
-      "version": "1.89.0",
+      "version": "1.93.0",
       "outputs_to_install": [
         "out"
       ],
       "outputs": {
-        "out": "/nix/store/gzv6psv17kv7x9s01w8jhi0h2cg6z15p-cargo-1.89.0"
+        "out": "/nix/store/v21x5yl04z0l303iz6ir5aqy9jzzrn76-cargo-1.93.0"
       },
       "system": "aarch64-darwin",
       "group": "rust-toolchain",
@@ -246,27 +246,27 @@
     {
       "attr_path": "cargo",
       "broken": false,
-      "derivation": "/nix/store/zzvvx666fnafml24c1iavi500vhx57v6-cargo-1.89.0.drv",
+      "derivation": "/nix/store/ckc3078ppx7ran8s00yqh1sijqn2df40-cargo-1.93.0.drv",
       "description": "Downloads your Rust project's dependencies and builds your project",
       "install_id": "cargo",
       "license": "[ MIT, Apache-2.0 ]",
-      "locked_url": "https://github.com/flox/nixpkgs?rev=554be6495561ff07b6c724047bdd7e0716aa7b46",
-      "name": "cargo-1.89.0",
+      "locked_url": "https://github.com/flox/nixpkgs?rev=aca4d95fce4914b3892661bcb80b8087293536c6",
+      "name": "cargo-1.93.0",
       "pname": "cargo",
-      "rev": "554be6495561ff07b6c724047bdd7e0716aa7b46",
-      "rev_count": 864611,
-      "rev_date": "2025-09-21T03:59:47Z",
-      "scrape_date": "2025-09-24T03:27:47.681307Z",
+      "rev": "aca4d95fce4914b3892661bcb80b8087293536c6",
+      "rev_count": 958961,
+      "rev_date": "2026-03-06T04:56:59Z",
+      "scrape_date": "2026-03-08T05:23:24.003458Z",
       "stabilities": [
         "unstable"
       ],
       "unfree": false,
-      "version": "1.89.0",
+      "version": "1.93.0",
       "outputs_to_install": [
         "out"
       ],
       "outputs": {
-        "out": "/nix/store/ahyjafkgyn6zji9qlvv92z8gxmcmaky4-cargo-1.89.0"
+        "out": "/nix/store/s7hb3dlngzws3rxjd30x9n6c7l2vmx2f-cargo-1.93.0"
       },
       "system": "aarch64-linux",
       "group": "rust-toolchain",
@@ -275,27 +275,27 @@
     {
       "attr_path": "cargo",
       "broken": false,
-      "derivation": "/nix/store/l9wpmjjm0900hmpclgd98i2y2mvj2b6z-cargo-1.89.0.drv",
+      "derivation": "/nix/store/ikmljbsqzncd6inlpkinl7mnf8hrwaz6-cargo-1.93.0.drv",
       "description": "Downloads your Rust project's dependencies and builds your project",
       "install_id": "cargo",
       "license": "[ MIT, Apache-2.0 ]",
-      "locked_url": "https://github.com/flox/nixpkgs?rev=554be6495561ff07b6c724047bdd7e0716aa7b46",
-      "name": "cargo-1.89.0",
+      "locked_url": "https://github.com/flox/nixpkgs?rev=aca4d95fce4914b3892661bcb80b8087293536c6",
+      "name": "cargo-1.93.0",
       "pname": "cargo",
-      "rev": "554be6495561ff07b6c724047bdd7e0716aa7b46",
-      "rev_count": 864611,
-      "rev_date": "2025-09-21T03:59:47Z",
-      "scrape_date": "2025-09-24T03:55:28.026529Z",
+      "rev": "aca4d95fce4914b3892661bcb80b8087293536c6",
+      "rev_count": 958961,
+      "rev_date": "2026-03-06T04:56:59Z",
+      "scrape_date": "2026-03-08T06:03:48.759355Z",
       "stabilities": [
         "unstable"
       ],
       "unfree": false,
-      "version": "1.89.0",
+      "version": "1.93.0",
       "outputs_to_install": [
         "out"
       ],
       "outputs": {
-        "out": "/nix/store/2a5rg88c4kc4mzjbbyah89c2hhyzjjp6-cargo-1.89.0"
+        "out": "/nix/store/js7zd17w17ha6na0qj2rb052rpgjm69l-cargo-1.93.0"
       },
       "system": "x86_64-darwin",
       "group": "rust-toolchain",
@@ -304,27 +304,27 @@
     {
       "attr_path": "cargo",
       "broken": false,
-      "derivation": "/nix/store/0f5ann1sgwyp31vlfqqsnr95xzv3mzhf-cargo-1.89.0.drv",
+      "derivation": "/nix/store/78m30da5gvpq8ppak7wx4jsxhz8j6mp4-cargo-1.93.0.drv",
       "description": "Downloads your Rust project's dependencies and builds your project",
       "install_id": "cargo",
       "license": "[ MIT, Apache-2.0 ]",
-      "locked_url": "https://github.com/flox/nixpkgs?rev=554be6495561ff07b6c724047bdd7e0716aa7b46",
-      "name": "cargo-1.89.0",
+      "locked_url": "https://github.com/flox/nixpkgs?rev=aca4d95fce4914b3892661bcb80b8087293536c6",
+      "name": "cargo-1.93.0",
       "pname": "cargo",
-      "rev": "554be6495561ff07b6c724047bdd7e0716aa7b46",
-      "rev_count": 864611,
-      "rev_date": "2025-09-21T03:59:47Z",
-      "scrape_date": "2025-09-24T04:26:37.856517Z",
+      "rev": "aca4d95fce4914b3892661bcb80b8087293536c6",
+      "rev_count": 958961,
+      "rev_date": "2026-03-06T04:56:59Z",
+      "scrape_date": "2026-03-08T06:46:39.032255Z",
       "stabilities": [
         "unstable"
       ],
       "unfree": false,
-      "version": "1.89.0",
+      "version": "1.93.0",
       "outputs_to_install": [
         "out"
       ],
       "outputs": {
-        "out": "/nix/store/xq6ns6hdgl7fdshisp5mb65f1jlysm0h-cargo-1.89.0"
+        "out": "/nix/store/p96faw8wiwi10cy94hr42gzmiapv15fm-cargo-1.93.0"
       },
       "system": "x86_64-linux",
       "group": "rust-toolchain",
@@ -333,27 +333,27 @@
     {
       "attr_path": "clippy",
       "broken": false,
-      "derivation": "/nix/store/ycvkay64j1bx14z7p1w07lqa45gx09yj-clippy-1.89.0.drv",
+      "derivation": "/nix/store/f66mjnyl489vckijcgnhczqapwpxi16x-clippy-1.93.0.drv",
       "description": "Bunch of lints to catch common mistakes and improve your Rust code",
       "install_id": "clippy",
       "license": "[ MIT, Apache-2.0 ]",
-      "locked_url": "https://github.com/flox/nixpkgs?rev=554be6495561ff07b6c724047bdd7e0716aa7b46",
-      "name": "clippy-1.89.0",
+      "locked_url": "https://github.com/flox/nixpkgs?rev=aca4d95fce4914b3892661bcb80b8087293536c6",
+      "name": "clippy-1.93.0",
       "pname": "clippy",
-      "rev": "554be6495561ff07b6c724047bdd7e0716aa7b46",
-      "rev_count": 864611,
-      "rev_date": "2025-09-21T03:59:47Z",
-      "scrape_date": "2025-09-24T02:58:44.828921Z",
+      "rev": "aca4d95fce4914b3892661bcb80b8087293536c6",
+      "rev_count": 958961,
+      "rev_date": "2026-03-06T04:56:59Z",
+      "scrape_date": "2026-03-08T04:46:43.313426Z",
       "stabilities": [
         "unstable"
       ],
       "unfree": false,
-      "version": "1.89.0",
+      "version": "1.93.0",
       "outputs_to_install": [
         "out"
       ],
       "outputs": {
-        "out": "/nix/store/lir6xy0c48yv9ql01rh37j1pn7aprx26-clippy-1.89.0"
+        "out": "/nix/store/xaqjf38v233s2i60jpjhv9akyd5zkw0m-clippy-1.93.0"
       },
       "system": "aarch64-darwin",
       "group": "rust-toolchain",
@@ -362,28 +362,28 @@
     {
       "attr_path": "clippy",
       "broken": false,
-      "derivation": "/nix/store/6ksrgky10gdrd0ahdikfs6zqgd2l2cyv-clippy-1.89.0.drv",
+      "derivation": "/nix/store/5y913f8xjn43gbagxj5dkkbqjswdd9j0-clippy-1.93.0.drv",
       "description": "Bunch of lints to catch common mistakes and improve your Rust code",
       "install_id": "clippy",
       "license": "[ MIT, Apache-2.0 ]",
-      "locked_url": "https://github.com/flox/nixpkgs?rev=554be6495561ff07b6c724047bdd7e0716aa7b46",
-      "name": "clippy-1.89.0",
+      "locked_url": "https://github.com/flox/nixpkgs?rev=aca4d95fce4914b3892661bcb80b8087293536c6",
+      "name": "clippy-1.93.0",
       "pname": "clippy",
-      "rev": "554be6495561ff07b6c724047bdd7e0716aa7b46",
-      "rev_count": 864611,
-      "rev_date": "2025-09-21T03:59:47Z",
-      "scrape_date": "2025-09-24T03:27:47.907835Z",
+      "rev": "aca4d95fce4914b3892661bcb80b8087293536c6",
+      "rev_count": 958961,
+      "rev_date": "2026-03-06T04:56:59Z",
+      "scrape_date": "2026-03-08T05:23:24.239504Z",
       "stabilities": [
         "unstable"
       ],
       "unfree": false,
-      "version": "1.89.0",
+      "version": "1.93.0",
       "outputs_to_install": [
         "out"
       ],
       "outputs": {
-        "debug": "/nix/store/clcyvq3wnj9hcpi55c0735999p1x7blr-clippy-1.89.0-debug",
-        "out": "/nix/store/7yrdzgagn32yvn6l0g9m7jgj113l9271-clippy-1.89.0"
+        "debug": "/nix/store/2p0f4abpa9w0cgi7853ad8fqiv4rzsv2-clippy-1.93.0-debug",
+        "out": "/nix/store/gypngfg4hdpsfvjpswa95g77zz47r78v-clippy-1.93.0"
       },
       "system": "aarch64-linux",
       "group": "rust-toolchain",
@@ -392,27 +392,27 @@
     {
       "attr_path": "clippy",
       "broken": false,
-      "derivation": "/nix/store/0zv2brsf0myff6ahfqgy7yhraqn8ln5z-clippy-1.89.0.drv",
+      "derivation": "/nix/store/by3k4vd3fwl0b24qzlvi3z06i7whhkfb-clippy-1.93.0.drv",
       "description": "Bunch of lints to catch common mistakes and improve your Rust code",
       "install_id": "clippy",
       "license": "[ MIT, Apache-2.0 ]",
-      "locked_url": "https://github.com/flox/nixpkgs?rev=554be6495561ff07b6c724047bdd7e0716aa7b46",
-      "name": "clippy-1.89.0",
+      "locked_url": "https://github.com/flox/nixpkgs?rev=aca4d95fce4914b3892661bcb80b8087293536c6",
+      "name": "clippy-1.93.0",
       "pname": "clippy",
-      "rev": "554be6495561ff07b6c724047bdd7e0716aa7b46",
-      "rev_count": 864611,
-      "rev_date": "2025-09-21T03:59:47Z",
-      "scrape_date": "2025-09-24T03:55:28.203376Z",
+      "rev": "aca4d95fce4914b3892661bcb80b8087293536c6",
+      "rev_count": 958961,
+      "rev_date": "2026-03-06T04:56:59Z",
+      "scrape_date": "2026-03-08T06:03:48.941442Z",
       "stabilities": [
         "unstable"
       ],
       "unfree": false,
-      "version": "1.89.0",
+      "version": "1.93.0",
       "outputs_to_install": [
         "out"
       ],
       "outputs": {
-        "out": "/nix/store/khg7wkc43bigb8l9gf8snj5b80lylyld-clippy-1.89.0"
+        "out": "/nix/store/i3m6fpdk1n1nqbb5gqzyjsn1lksqp60b-clippy-1.93.0"
       },
       "system": "x86_64-darwin",
       "group": "rust-toolchain",
@@ -421,28 +421,28 @@
     {
       "attr_path": "clippy",
       "broken": false,
-      "derivation": "/nix/store/rnrv0yxmmvmqysygkng25zsb524w0p5d-clippy-1.89.0.drv",
+      "derivation": "/nix/store/dcs56hyfzvi59dmf8p66grskn1qj5fan-clippy-1.93.0.drv",
       "description": "Bunch of lints to catch common mistakes and improve your Rust code",
       "install_id": "clippy",
       "license": "[ MIT, Apache-2.0 ]",
-      "locked_url": "https://github.com/flox/nixpkgs?rev=554be6495561ff07b6c724047bdd7e0716aa7b46",
-      "name": "clippy-1.89.0",
+      "locked_url": "https://github.com/flox/nixpkgs?rev=aca4d95fce4914b3892661bcb80b8087293536c6",
+      "name": "clippy-1.93.0",
       "pname": "clippy",
-      "rev": "554be6495561ff07b6c724047bdd7e0716aa7b46",
-      "rev_count": 864611,
-      "rev_date": "2025-09-21T03:59:47Z",
-      "scrape_date": "2025-09-24T04:26:38.107236Z",
+      "rev": "aca4d95fce4914b3892661bcb80b8087293536c6",
+      "rev_count": 958961,
+      "rev_date": "2026-03-06T04:56:59Z",
+      "scrape_date": "2026-03-08T06:46:39.281502Z",
       "stabilities": [
         "unstable"
       ],
       "unfree": false,
-      "version": "1.89.0",
+      "version": "1.93.0",
       "outputs_to_install": [
         "out"
       ],
       "outputs": {
-        "debug": "/nix/store/81c1ha8p1dscxbksy1zgdm9b5pga7gpz-clippy-1.89.0-debug",
-        "out": "/nix/store/mzsh6fr9kzck0xh97d9kfd8h2iyfcyfb-clippy-1.89.0"
+        "debug": "/nix/store/5v47mbiidhck8rzw141hvmwkh515pfg3-clippy-1.93.0-debug",
+        "out": "/nix/store/0yj3hz7imj1zxmppn9gfps8h2jmvdi7g-clippy-1.93.0"
       },
       "system": "x86_64-linux",
       "group": "rust-toolchain",
@@ -451,15 +451,15 @@
     {
       "attr_path": "rustPlatform.rustLibSrc",
       "broken": false,
-      "derivation": "/nix/store/s21qvhv8hzb2gmcvmfyp6b00zpd182k6-rust-lib-src.drv",
+      "derivation": "/nix/store/yz2f2d76yswbdaczcfsf7zij14d6k1gd-rust-lib-src.drv",
       "install_id": "rust-lib-src",
-      "locked_url": "https://github.com/flox/nixpkgs?rev=554be6495561ff07b6c724047bdd7e0716aa7b46",
+      "locked_url": "https://github.com/flox/nixpkgs?rev=aca4d95fce4914b3892661bcb80b8087293536c6",
       "name": "rust-lib-src",
       "pname": "rustLibSrc",
-      "rev": "554be6495561ff07b6c724047bdd7e0716aa7b46",
-      "rev_count": 864611,
-      "rev_date": "2025-09-21T03:59:47Z",
-      "scrape_date": "2025-09-24T03:01:13.450679Z",
+      "rev": "aca4d95fce4914b3892661bcb80b8087293536c6",
+      "rev_count": 958961,
+      "rev_date": "2026-03-06T04:56:59Z",
+      "scrape_date": "2026-03-08T04:49:23.791549Z",
       "stabilities": [
         "unstable"
       ],
@@ -469,7 +469,7 @@
         "out"
       ],
       "outputs": {
-        "out": "/nix/store/90x1dg19kg8slq7jk5zvix7f7q7j51xq-rust-lib-src"
+        "out": "/nix/store/mfl3c8ckwk1cviaa2kgavlyhyvj7siab-rust-lib-src"
       },
       "system": "aarch64-darwin",
       "group": "rust-toolchain",
@@ -478,15 +478,15 @@
     {
       "attr_path": "rustPlatform.rustLibSrc",
       "broken": false,
-      "derivation": "/nix/store/74c0xd1305d2nl7rn9cyrjgy61dlb3a6-rust-lib-src.drv",
+      "derivation": "/nix/store/7lmxl2qm5dlryycs048n6p9qb6xydg0m-rust-lib-src.drv",
       "install_id": "rust-lib-src",
-      "locked_url": "https://github.com/flox/nixpkgs?rev=554be6495561ff07b6c724047bdd7e0716aa7b46",
+      "locked_url": "https://github.com/flox/nixpkgs?rev=aca4d95fce4914b3892661bcb80b8087293536c6",
       "name": "rust-lib-src",
       "pname": "rustLibSrc",
-      "rev": "554be6495561ff07b6c724047bdd7e0716aa7b46",
-      "rev_count": 864611,
-      "rev_date": "2025-09-21T03:59:47Z",
-      "scrape_date": "2025-09-24T03:31:08.095409Z",
+      "rev": "aca4d95fce4914b3892661bcb80b8087293536c6",
+      "rev_count": 958961,
+      "rev_date": "2026-03-06T04:56:59Z",
+      "scrape_date": "2026-03-08T05:27:04.413831Z",
       "stabilities": [
         "unstable"
       ],
@@ -496,7 +496,7 @@
         "out"
       ],
       "outputs": {
-        "out": "/nix/store/v6warxcrlb1ksscwp9dywbskmsdpw9wv-rust-lib-src"
+        "out": "/nix/store/c4d03kawid9k3dgglbla64kl12nciwz5-rust-lib-src"
       },
       "system": "aarch64-linux",
       "group": "rust-toolchain",
@@ -505,15 +505,15 @@
     {
       "attr_path": "rustPlatform.rustLibSrc",
       "broken": false,
-      "derivation": "/nix/store/p40zkwiym67p1s1ng1826vv3x2bvfbia-rust-lib-src.drv",
+      "derivation": "/nix/store/qrqg7v1izjmpfip5ai31w5ny2pvcv0zq-rust-lib-src.drv",
       "install_id": "rust-lib-src",
-      "locked_url": "https://github.com/flox/nixpkgs?rev=554be6495561ff07b6c724047bdd7e0716aa7b46",
+      "locked_url": "https://github.com/flox/nixpkgs?rev=aca4d95fce4914b3892661bcb80b8087293536c6",
       "name": "rust-lib-src",
       "pname": "rustLibSrc",
-      "rev": "554be6495561ff07b6c724047bdd7e0716aa7b46",
-      "rev_count": 864611,
-      "rev_date": "2025-09-21T03:59:47Z",
-      "scrape_date": "2025-09-24T03:58:06.814061Z",
+      "rev": "aca4d95fce4914b3892661bcb80b8087293536c6",
+      "rev_count": 958961,
+      "rev_date": "2026-03-06T04:56:59Z",
+      "scrape_date": "2026-03-08T06:06:25.570041Z",
       "stabilities": [
         "unstable"
       ],
@@ -523,7 +523,7 @@
         "out"
       ],
       "outputs": {
-        "out": "/nix/store/na43p9zh9d0x222vva4mb2b34anhj4l2-rust-lib-src"
+        "out": "/nix/store/gqmy70a3k7qfr6xi5rhzpx2a6ql79xr1-rust-lib-src"
       },
       "system": "x86_64-darwin",
       "group": "rust-toolchain",
@@ -532,15 +532,15 @@
     {
       "attr_path": "rustPlatform.rustLibSrc",
       "broken": false,
-      "derivation": "/nix/store/74hdj06bvh6rx572jr2jwx30jpkbnkyz-rust-lib-src.drv",
+      "derivation": "/nix/store/xz19iprk4yz00zp5x5zibwv98jafgf1b-rust-lib-src.drv",
       "install_id": "rust-lib-src",
-      "locked_url": "https://github.com/flox/nixpkgs?rev=554be6495561ff07b6c724047bdd7e0716aa7b46",
+      "locked_url": "https://github.com/flox/nixpkgs?rev=aca4d95fce4914b3892661bcb80b8087293536c6",
       "name": "rust-lib-src",
       "pname": "rustLibSrc",
-      "rev": "554be6495561ff07b6c724047bdd7e0716aa7b46",
-      "rev_count": 864611,
-      "rev_date": "2025-09-21T03:59:47Z",
-      "scrape_date": "2025-09-24T04:30:24.553486Z",
+      "rev": "aca4d95fce4914b3892661bcb80b8087293536c6",
+      "rev_count": 958961,
+      "rev_date": "2026-03-06T04:56:59Z",
+      "scrape_date": "2026-03-08T06:50:30.529065Z",
       "stabilities": [
         "unstable"
       ],
@@ -550,7 +550,7 @@
         "out"
       ],
       "outputs": {
-        "out": "/nix/store/497imwr2k586w2ll2r8rji5jz92f2y9j-rust-lib-src"
+        "out": "/nix/store/xqnf1bdi96i044mgfqvw9kll3554nbr9-rust-lib-src"
       },
       "system": "x86_64-linux",
       "group": "rust-toolchain",
@@ -559,30 +559,30 @@
     {
       "attr_path": "rustc",
       "broken": false,
-      "derivation": "/nix/store/h7y7alkm8wya8dj6ifwbmfm55kfr2awx-rustc-wrapper-1.89.0.drv",
+      "derivation": "/nix/store/a7bh0djq187jyr87pw7r7r9fyqbys8bc-rustc-wrapper-1.93.0.drv",
       "description": "Safe, concurrent, practical language (wrapper script)",
       "install_id": "rustc",
       "license": "[ MIT, Apache-2.0 ]",
-      "locked_url": "https://github.com/flox/nixpkgs?rev=554be6495561ff07b6c724047bdd7e0716aa7b46",
-      "name": "rustc-wrapper-1.89.0",
+      "locked_url": "https://github.com/flox/nixpkgs?rev=aca4d95fce4914b3892661bcb80b8087293536c6",
+      "name": "rustc-wrapper-1.93.0",
       "pname": "rustc",
-      "rev": "554be6495561ff07b6c724047bdd7e0716aa7b46",
-      "rev_count": 864611,
-      "rev_date": "2025-09-21T03:59:47Z",
-      "scrape_date": "2025-09-24T03:00:12.046441Z",
+      "rev": "aca4d95fce4914b3892661bcb80b8087293536c6",
+      "rev_count": 958961,
+      "rev_date": "2026-03-06T04:56:59Z",
+      "scrape_date": "2026-03-08T04:48:13.275663Z",
       "stabilities": [
         "unstable"
       ],
       "unfree": false,
-      "version": "1.89.0",
+      "version": "1.93.0",
       "outputs_to_install": [
         "man",
         "out"
       ],
       "outputs": {
-        "doc": "/nix/store/jbw8jvpsjglk09wyxknnjfrsy42x654d-rustc-wrapper-1.89.0-doc",
-        "man": "/nix/store/hqw8xk2qvyv7afmvllj2c4lzxylacw92-rustc-wrapper-1.89.0-man",
-        "out": "/nix/store/ir2arizs2b2azr189dmyg4lhp0vps9nn-rustc-wrapper-1.89.0"
+        "doc": "/nix/store/cvfmwvv2cff024icpb1flb1dj65h0l7r-rustc-wrapper-1.93.0-doc",
+        "man": "/nix/store/181zg8zlv5xcs0b42vbs0j48n7csihwn-rustc-wrapper-1.93.0-man",
+        "out": "/nix/store/aw92hggrw3z08jhc7ayl3l5x5nwq89cn-rustc-wrapper-1.93.0"
       },
       "system": "aarch64-darwin",
       "group": "rust-toolchain",
@@ -591,30 +591,30 @@
     {
       "attr_path": "rustc",
       "broken": false,
-      "derivation": "/nix/store/qa2jln5j19qim4npi9dhqrdm3isydm2x-rustc-wrapper-1.89.0.drv",
+      "derivation": "/nix/store/awhw5bm0131rmim2nfv4xs45qqw5x3j3-rustc-wrapper-1.93.0.drv",
       "description": "Safe, concurrent, practical language (wrapper script)",
       "install_id": "rustc",
       "license": "[ MIT, Apache-2.0 ]",
-      "locked_url": "https://github.com/flox/nixpkgs?rev=554be6495561ff07b6c724047bdd7e0716aa7b46",
-      "name": "rustc-wrapper-1.89.0",
+      "locked_url": "https://github.com/flox/nixpkgs?rev=aca4d95fce4914b3892661bcb80b8087293536c6",
+      "name": "rustc-wrapper-1.93.0",
       "pname": "rustc",
-      "rev": "554be6495561ff07b6c724047bdd7e0716aa7b46",
-      "rev_count": 864611,
-      "rev_date": "2025-09-21T03:59:47Z",
-      "scrape_date": "2025-09-24T03:29:49.294915Z",
+      "rev": "aca4d95fce4914b3892661bcb80b8087293536c6",
+      "rev_count": 958961,
+      "rev_date": "2026-03-06T04:56:59Z",
+      "scrape_date": "2026-03-08T05:25:28.921801Z",
       "stabilities": [
         "unstable"
       ],
       "unfree": false,
-      "version": "1.89.0",
+      "version": "1.93.0",
       "outputs_to_install": [
         "man",
         "out"
       ],
       "outputs": {
-        "doc": "/nix/store/kwaljcc4wij7gn4g6w7g1chdgyhgfv17-rustc-wrapper-1.89.0-doc",
-        "man": "/nix/store/n1xxlafvvfa6yy0bqpifv95vz2nyfjyn-rustc-wrapper-1.89.0-man",
-        "out": "/nix/store/yxh9cs2lshqgk6h0kp256yms3w8qwmsz-rustc-wrapper-1.89.0"
+        "doc": "/nix/store/r7xcg85wrwc19a1czwmlj1spn4pp38dn-rustc-wrapper-1.93.0-doc",
+        "man": "/nix/store/2i84bq802hhxgx7wmrw3p5xhh4rqabim-rustc-wrapper-1.93.0-man",
+        "out": "/nix/store/98dvh18vbqmckqw0pqp8iwh1imkax381-rustc-wrapper-1.93.0"
       },
       "system": "aarch64-linux",
       "group": "rust-toolchain",
@@ -623,30 +623,30 @@
     {
       "attr_path": "rustc",
       "broken": false,
-      "derivation": "/nix/store/d4hipi0d0csrs077yzjd13s5daj2fh4v-rustc-wrapper-1.89.0.drv",
+      "derivation": "/nix/store/66zmyl0pn61c01z1mqggpssiqyrhspdp-rustc-wrapper-1.93.0.drv",
       "description": "Safe, concurrent, practical language (wrapper script)",
       "install_id": "rustc",
       "license": "[ MIT, Apache-2.0 ]",
-      "locked_url": "https://github.com/flox/nixpkgs?rev=554be6495561ff07b6c724047bdd7e0716aa7b46",
-      "name": "rustc-wrapper-1.89.0",
+      "locked_url": "https://github.com/flox/nixpkgs?rev=aca4d95fce4914b3892661bcb80b8087293536c6",
+      "name": "rustc-wrapper-1.93.0",
       "pname": "rustc",
-      "rev": "554be6495561ff07b6c724047bdd7e0716aa7b46",
-      "rev_count": 864611,
-      "rev_date": "2025-09-21T03:59:47Z",
-      "scrape_date": "2025-09-24T03:57:00.398651Z",
+      "rev": "aca4d95fce4914b3892661bcb80b8087293536c6",
+      "rev_count": 958961,
+      "rev_date": "2026-03-06T04:56:59Z",
+      "scrape_date": "2026-03-08T06:05:16.820241Z",
       "stabilities": [
         "unstable"
       ],
       "unfree": false,
-      "version": "1.89.0",
+      "version": "1.93.0",
       "outputs_to_install": [
         "man",
         "out"
       ],
       "outputs": {
-        "doc": "/nix/store/7nkka183wnqgwdfd27a8bzkxwpczmbd1-rustc-wrapper-1.89.0-doc",
-        "man": "/nix/store/zainldlgd3zz8wsxgri4w4qlzdyrjhah-rustc-wrapper-1.89.0-man",
-        "out": "/nix/store/h1vqiwjdahfzvy9w192kz4pjqsic2bkp-rustc-wrapper-1.89.0"
+        "doc": "/nix/store/qnal9scf4rwq17qr0fvwqkashl6mi0g8-rustc-wrapper-1.93.0-doc",
+        "man": "/nix/store/nwswdhsyiv342bvfhmfas3i0gdbr4b2b-rustc-wrapper-1.93.0-man",
+        "out": "/nix/store/5vvf4xg0rqwkl9d4p2nx2nl1bpy2gq4w-rustc-wrapper-1.93.0"
       },
       "system": "x86_64-darwin",
       "group": "rust-toolchain",
@@ -655,30 +655,30 @@
     {
       "attr_path": "rustc",
       "broken": false,
-      "derivation": "/nix/store/4bycw2rdgf33gmn1z26knv8grxxh06w5-rustc-wrapper-1.89.0.drv",
+      "derivation": "/nix/store/if4bjnn98w70c7jwypqng8s1lhaxr59h-rustc-wrapper-1.93.0.drv",
       "description": "Safe, concurrent, practical language (wrapper script)",
       "install_id": "rustc",
       "license": "[ MIT, Apache-2.0 ]",
-      "locked_url": "https://github.com/flox/nixpkgs?rev=554be6495561ff07b6c724047bdd7e0716aa7b46",
-      "name": "rustc-wrapper-1.89.0",
+      "locked_url": "https://github.com/flox/nixpkgs?rev=aca4d95fce4914b3892661bcb80b8087293536c6",
+      "name": "rustc-wrapper-1.93.0",
       "pname": "rustc",
-      "rev": "554be6495561ff07b6c724047bdd7e0716aa7b46",
-      "rev_count": 864611,
-      "rev_date": "2025-09-21T03:59:47Z",
-      "scrape_date": "2025-09-24T04:28:55.400672Z",
+      "rev": "aca4d95fce4914b3892661bcb80b8087293536c6",
+      "rev_count": 958961,
+      "rev_date": "2026-03-06T04:56:59Z",
+      "scrape_date": "2026-03-08T06:48:53.991908Z",
       "stabilities": [
         "unstable"
       ],
       "unfree": false,
-      "version": "1.89.0",
+      "version": "1.93.0",
       "outputs_to_install": [
         "man",
         "out"
       ],
       "outputs": {
-        "doc": "/nix/store/7ns2kwk74yn86csi2cpcxpnl3qg32s19-rustc-wrapper-1.89.0-doc",
-        "man": "/nix/store/1qas0d89hs3lzccywq1zhpwgf3rnh8p1-rustc-wrapper-1.89.0-man",
-        "out": "/nix/store/hcginxlb1vivl6v6vjmi61s96082270d-rustc-wrapper-1.89.0"
+        "doc": "/nix/store/jxsjbrzcxww6v7g4n4fqcw6sj7z7s3y9-rustc-wrapper-1.93.0-doc",
+        "man": "/nix/store/kfxswj02a5bskwnwn3jdz3micybbaw2r-rustc-wrapper-1.93.0-man",
+        "out": "/nix/store/rsy1282lj3dg4wdf5d00yvz7f6hjzxin-rustc-wrapper-1.93.0"
       },
       "system": "x86_64-linux",
       "group": "rust-toolchain",
@@ -687,27 +687,27 @@
     {
       "attr_path": "rustfmt",
       "broken": false,
-      "derivation": "/nix/store/k77vdn728hkvsbplrmkrsnm39ccp6l9h-rustfmt-1.89.0.drv",
+      "derivation": "/nix/store/v62rjdaw5yvmvbcjn67wrifl1g9bfnhi-rustfmt-1.93.0.drv",
       "description": "Tool for formatting Rust code according to style guidelines",
       "install_id": "rustfmt",
       "license": "[ MIT, Apache-2.0 ]",
-      "locked_url": "https://github.com/flox/nixpkgs?rev=554be6495561ff07b6c724047bdd7e0716aa7b46",
-      "name": "rustfmt-1.89.0",
+      "locked_url": "https://github.com/flox/nixpkgs?rev=aca4d95fce4914b3892661bcb80b8087293536c6",
+      "name": "rustfmt-1.93.0",
       "pname": "rustfmt",
-      "rev": "554be6495561ff07b6c724047bdd7e0716aa7b46",
-      "rev_count": 864611,
-      "rev_date": "2025-09-21T03:59:47Z",
-      "scrape_date": "2025-09-24T03:00:12.065347Z",
+      "rev": "aca4d95fce4914b3892661bcb80b8087293536c6",
+      "rev_count": 958961,
+      "rev_date": "2026-03-06T04:56:59Z",
+      "scrape_date": "2026-03-08T04:48:13.296848Z",
       "stabilities": [
         "unstable"
       ],
       "unfree": false,
-      "version": "1.89.0",
+      "version": "1.93.0",
       "outputs_to_install": [
         "out"
       ],
       "outputs": {
-        "out": "/nix/store/m46axwglrbpxm3d0a2zzm62wpv956461-rustfmt-1.89.0"
+        "out": "/nix/store/9aq18v5y6ss8yrlfzqwrsq8j0ilm7mgp-rustfmt-1.93.0"
       },
       "system": "aarch64-darwin",
       "group": "rust-toolchain",
@@ -716,27 +716,27 @@
     {
       "attr_path": "rustfmt",
       "broken": false,
-      "derivation": "/nix/store/b6fhwkpl91c9sxd7y7rzhgwwrbg70rr6-rustfmt-1.89.0.drv",
+      "derivation": "/nix/store/hv2c84414j3r7vq8jampji6nxz5w6f71-rustfmt-1.93.0.drv",
       "description": "Tool for formatting Rust code according to style guidelines",
       "install_id": "rustfmt",
       "license": "[ MIT, Apache-2.0 ]",
-      "locked_url": "https://github.com/flox/nixpkgs?rev=554be6495561ff07b6c724047bdd7e0716aa7b46",
-      "name": "rustfmt-1.89.0",
+      "locked_url": "https://github.com/flox/nixpkgs?rev=aca4d95fce4914b3892661bcb80b8087293536c6",
+      "name": "rustfmt-1.93.0",
       "pname": "rustfmt",
-      "rev": "554be6495561ff07b6c724047bdd7e0716aa7b46",
-      "rev_count": 864611,
-      "rev_date": "2025-09-21T03:59:47Z",
-      "scrape_date": "2025-09-24T03:29:49.323257Z",
+      "rev": "aca4d95fce4914b3892661bcb80b8087293536c6",
+      "rev_count": 958961,
+      "rev_date": "2026-03-06T04:56:59Z",
+      "scrape_date": "2026-03-08T05:25:28.953110Z",
       "stabilities": [
         "unstable"
       ],
       "unfree": false,
-      "version": "1.89.0",
+      "version": "1.93.0",
       "outputs_to_install": [
         "out"
       ],
       "outputs": {
-        "out": "/nix/store/lk7ill5b5n7rivr3b24q7gszjdgw7xdh-rustfmt-1.89.0"
+        "out": "/nix/store/4aq1qa0xy4z06a2bdn5l6plhj28a0rq5-rustfmt-1.93.0"
       },
       "system": "aarch64-linux",
       "group": "rust-toolchain",
@@ -745,27 +745,27 @@
     {
       "attr_path": "rustfmt",
       "broken": false,
-      "derivation": "/nix/store/jj3jfqcwpqzh1pdxwry57rw2diwwsmny-rustfmt-1.89.0.drv",
+      "derivation": "/nix/store/wsfm30acmqdy14rmnws6c07wkb72zkr9-rustfmt-1.93.0.drv",
       "description": "Tool for formatting Rust code according to style guidelines",
       "install_id": "rustfmt",
       "license": "[ MIT, Apache-2.0 ]",
-      "locked_url": "https://github.com/flox/nixpkgs?rev=554be6495561ff07b6c724047bdd7e0716aa7b46",
-      "name": "rustfmt-1.89.0",
+      "locked_url": "https://github.com/flox/nixpkgs?rev=aca4d95fce4914b3892661bcb80b8087293536c6",
+      "name": "rustfmt-1.93.0",
       "pname": "rustfmt",
-      "rev": "554be6495561ff07b6c724047bdd7e0716aa7b46",
-      "rev_count": 864611,
-      "rev_date": "2025-09-21T03:59:47Z",
-      "scrape_date": "2025-09-24T03:57:00.418422Z",
+      "rev": "aca4d95fce4914b3892661bcb80b8087293536c6",
+      "rev_count": 958961,
+      "rev_date": "2026-03-06T04:56:59Z",
+      "scrape_date": "2026-03-08T06:05:16.841163Z",
       "stabilities": [
         "unstable"
       ],
       "unfree": false,
-      "version": "1.89.0",
+      "version": "1.93.0",
       "outputs_to_install": [
         "out"
       ],
       "outputs": {
-        "out": "/nix/store/x0x8ikn0gz0alg07fh0hnf0znl2mzm2m-rustfmt-1.89.0"
+        "out": "/nix/store/1ql1g2a253djjz10x019wii04d2dijjr-rustfmt-1.93.0"
       },
       "system": "x86_64-darwin",
       "group": "rust-toolchain",
@@ -774,27 +774,27 @@
     {
       "attr_path": "rustfmt",
       "broken": false,
-      "derivation": "/nix/store/vldixnarn8sh84ls0lcq7qxh1ga5x8gd-rustfmt-1.89.0.drv",
+      "derivation": "/nix/store/q34vqppwb9yxw48dy7i8nbsb41ixysjs-rustfmt-1.93.0.drv",
       "description": "Tool for formatting Rust code according to style guidelines",
       "install_id": "rustfmt",
       "license": "[ MIT, Apache-2.0 ]",
-      "locked_url": "https://github.com/flox/nixpkgs?rev=554be6495561ff07b6c724047bdd7e0716aa7b46",
-      "name": "rustfmt-1.89.0",
+      "locked_url": "https://github.com/flox/nixpkgs?rev=aca4d95fce4914b3892661bcb80b8087293536c6",
+      "name": "rustfmt-1.93.0",
       "pname": "rustfmt",
-      "rev": "554be6495561ff07b6c724047bdd7e0716aa7b46",
-      "rev_count": 864611,
-      "rev_date": "2025-09-21T03:59:47Z",
-      "scrape_date": "2025-09-24T04:28:55.434882Z",
+      "rev": "aca4d95fce4914b3892661bcb80b8087293536c6",
+      "rev_count": 958961,
+      "rev_date": "2026-03-06T04:56:59Z",
+      "scrape_date": "2026-03-08T06:48:54.024810Z",
       "stabilities": [
         "unstable"
       ],
       "unfree": false,
-      "version": "1.89.0",
+      "version": "1.93.0",
       "outputs_to_install": [
         "out"
       ],
       "outputs": {
-        "out": "/nix/store/26qhfy2g59mg6q1y0xdgd8ji06v7vnww-rustfmt-1.89.0"
+        "out": "/nix/store/yb62fm7wf3ysn5rnfj2r03snmk9pwwa2-rustfmt-1.93.0"
       },
       "system": "x86_64-linux",
       "group": "rust-toolchain",
@@ -803,27 +803,27 @@
     {
       "attr_path": "cargo-hack",
       "broken": false,
-      "derivation": "/nix/store/v12fg56m70dvn48pz3vkhijwsvwa44hv-cargo-hack-0.6.38.drv",
+      "derivation": "/nix/store/6zzaybqkxbx482m3gspg0pv22069w99d-cargo-hack-0.6.43.drv",
       "description": "Cargo subcommand to provide various options useful for testing and continuous integration",
       "install_id": "cargo-hack",
       "license": "[ Apache-2.0, MIT ]",
-      "locked_url": "https://github.com/flox/nixpkgs?rev=c23193b943c6c689d70ee98ce3128239ed9e32d1",
-      "name": "cargo-hack-0.6.38",
+      "locked_url": "https://github.com/flox/nixpkgs?rev=aca4d95fce4914b3892661bcb80b8087293536c6",
+      "name": "cargo-hack-0.6.43",
       "pname": "cargo-hack",
-      "rev": "c23193b943c6c689d70ee98ce3128239ed9e32d1",
-      "rev_count": 861038,
-      "rev_date": "2025-09-13T06:43:22Z",
-      "scrape_date": "2025-09-15T02:00:42.306220Z",
+      "rev": "aca4d95fce4914b3892661bcb80b8087293536c6",
+      "rev_count": 958961,
+      "rev_date": "2026-03-06T04:56:59Z",
+      "scrape_date": "2026-03-08T04:46:43.139694Z",
       "stabilities": [
         "unstable"
       ],
       "unfree": false,
-      "version": "0.6.38",
+      "version": "0.6.43",
       "outputs_to_install": [
         "out"
       ],
       "outputs": {
-        "out": "/nix/store/5zam2ya0s5i3ljdaj4j7nb9957xc41l4-cargo-hack-0.6.38"
+        "out": "/nix/store/x34xdp0m1x1nk68yr26i671fdx29hbms-cargo-hack-0.6.43"
       },
       "system": "aarch64-darwin",
       "group": "toplevel",
@@ -832,27 +832,27 @@
     {
       "attr_path": "cargo-hack",
       "broken": false,
-      "derivation": "/nix/store/04ibm8p286lqfy1qxlgn2yj2kqqddxdf-cargo-hack-0.6.38.drv",
+      "derivation": "/nix/store/5yf7kxvm3gb51nm4hkkdjxda3j67q4h8-cargo-hack-0.6.43.drv",
       "description": "Cargo subcommand to provide various options useful for testing and continuous integration",
       "install_id": "cargo-hack",
       "license": "[ Apache-2.0, MIT ]",
-      "locked_url": "https://github.com/flox/nixpkgs?rev=c23193b943c6c689d70ee98ce3128239ed9e32d1",
-      "name": "cargo-hack-0.6.38",
+      "locked_url": "https://github.com/flox/nixpkgs?rev=aca4d95fce4914b3892661bcb80b8087293536c6",
+      "name": "cargo-hack-0.6.43",
       "pname": "cargo-hack",
-      "rev": "c23193b943c6c689d70ee98ce3128239ed9e32d1",
-      "rev_count": 861038,
-      "rev_date": "2025-09-13T06:43:22Z",
-      "scrape_date": "2025-09-15T02:29:40.217985Z",
+      "rev": "aca4d95fce4914b3892661bcb80b8087293536c6",
+      "rev_count": 958961,
+      "rev_date": "2026-03-06T04:56:59Z",
+      "scrape_date": "2026-03-08T05:23:24.012940Z",
       "stabilities": [
         "unstable"
       ],
       "unfree": false,
-      "version": "0.6.38",
+      "version": "0.6.43",
       "outputs_to_install": [
         "out"
       ],
       "outputs": {
-        "out": "/nix/store/71wlgkdh4qvwyqrv1v5ypsa3dyal7px7-cargo-hack-0.6.38"
+        "out": "/nix/store/pzx6ars6adj3zznwr8x1qvl1wfdl0hc2-cargo-hack-0.6.43"
       },
       "system": "aarch64-linux",
       "group": "toplevel",
@@ -861,27 +861,27 @@
     {
       "attr_path": "cargo-hack",
       "broken": false,
-      "derivation": "/nix/store/50q8jsw5569z4dc47xsx3mch94ipaa60-cargo-hack-0.6.38.drv",
+      "derivation": "/nix/store/yslln73ljv2q4v51fsvyw3nd202slxky-cargo-hack-0.6.43.drv",
       "description": "Cargo subcommand to provide various options useful for testing and continuous integration",
       "install_id": "cargo-hack",
       "license": "[ Apache-2.0, MIT ]",
-      "locked_url": "https://github.com/flox/nixpkgs?rev=c23193b943c6c689d70ee98ce3128239ed9e32d1",
-      "name": "cargo-hack-0.6.38",
+      "locked_url": "https://github.com/flox/nixpkgs?rev=aca4d95fce4914b3892661bcb80b8087293536c6",
+      "name": "cargo-hack-0.6.43",
       "pname": "cargo-hack",
-      "rev": "c23193b943c6c689d70ee98ce3128239ed9e32d1",
-      "rev_count": 861038,
-      "rev_date": "2025-09-13T06:43:22Z",
-      "scrape_date": "2025-09-15T02:56:35.701679Z",
+      "rev": "aca4d95fce4914b3892661bcb80b8087293536c6",
+      "rev_count": 958961,
+      "rev_date": "2026-03-06T04:56:59Z",
+      "scrape_date": "2026-03-08T06:03:48.767165Z",
       "stabilities": [
         "unstable"
       ],
       "unfree": false,
-      "version": "0.6.38",
+      "version": "0.6.43",
       "outputs_to_install": [
         "out"
       ],
       "outputs": {
-        "out": "/nix/store/0cyr2y0z9ps7mdb9bwzcrchpn98ab3n8-cargo-hack-0.6.38"
+        "out": "/nix/store/v3i29akng2mdnfgxv2v02bm9dl1x116z-cargo-hack-0.6.43"
       },
       "system": "x86_64-darwin",
       "group": "toplevel",
@@ -890,27 +890,27 @@
     {
       "attr_path": "cargo-hack",
       "broken": false,
-      "derivation": "/nix/store/d4ni0b16000hdiy59fmw25fzd73f6y7d-cargo-hack-0.6.38.drv",
+      "derivation": "/nix/store/3hgdl0ck5kmh03l1cwflqvq6yx27ivyi-cargo-hack-0.6.43.drv",
       "description": "Cargo subcommand to provide various options useful for testing and continuous integration",
       "install_id": "cargo-hack",
       "license": "[ Apache-2.0, MIT ]",
-      "locked_url": "https://github.com/flox/nixpkgs?rev=c23193b943c6c689d70ee98ce3128239ed9e32d1",
-      "name": "cargo-hack-0.6.38",
+      "locked_url": "https://github.com/flox/nixpkgs?rev=aca4d95fce4914b3892661bcb80b8087293536c6",
+      "name": "cargo-hack-0.6.43",
       "pname": "cargo-hack",
-      "rev": "c23193b943c6c689d70ee98ce3128239ed9e32d1",
-      "rev_count": 861038,
-      "rev_date": "2025-09-13T06:43:22Z",
-      "scrape_date": "2025-09-15T03:26:56.302167Z",
+      "rev": "aca4d95fce4914b3892661bcb80b8087293536c6",
+      "rev_count": 958961,
+      "rev_date": "2026-03-06T04:56:59Z",
+      "scrape_date": "2026-03-08T06:46:39.041750Z",
       "stabilities": [
         "unstable"
       ],
       "unfree": false,
-      "version": "0.6.38",
+      "version": "0.6.43",
       "outputs_to_install": [
         "out"
       ],
       "outputs": {
-        "out": "/nix/store/1dz43ai8djk0l827icddgsghsq53xc2p-cargo-hack-0.6.38"
+        "out": "/nix/store/v3i33iq5z1ayhycwmg4p404n5r0dh122-cargo-hack-0.6.43"
       },
       "system": "x86_64-linux",
       "group": "toplevel",
@@ -919,27 +919,27 @@
     {
       "attr_path": "clang",
       "broken": false,
-      "derivation": "/nix/store/wb65lsb0lqnf9km0jcs3vbyz5qi9aib4-clang-wrapper-19.1.7.drv",
+      "derivation": "/nix/store/5r194qjgmn23q4rd7q9v7s9pamazaias-clang-wrapper-21.1.8.drv",
       "description": "C language family frontend for LLVM (wrapper script)",
       "install_id": "clang",
       "license": "[ NCSA, Apache-2.0, LLVM-exception ]",
-      "locked_url": "https://github.com/flox/nixpkgs?rev=c23193b943c6c689d70ee98ce3128239ed9e32d1",
-      "name": "clang-wrapper-19.1.7",
+      "locked_url": "https://github.com/flox/nixpkgs?rev=aca4d95fce4914b3892661bcb80b8087293536c6",
+      "name": "clang-wrapper-21.1.8",
       "pname": "clang",
-      "rev": "c23193b943c6c689d70ee98ce3128239ed9e32d1",
-      "rev_count": 861038,
-      "rev_date": "2025-09-13T06:43:22Z",
-      "scrape_date": "2025-09-15T02:00:42.465872Z",
+      "rev": "aca4d95fce4914b3892661bcb80b8087293536c6",
+      "rev_count": 958961,
+      "rev_date": "2026-03-06T04:56:59Z",
+      "scrape_date": "2026-03-08T04:46:43.301328Z",
       "stabilities": [
         "unstable"
       ],
       "unfree": false,
-      "version": "19.1.7",
+      "version": "21.1.8",
       "outputs_to_install": [
         "out"
       ],
       "outputs": {
-        "out": "/nix/store/zzx6cfl99zknfrj9v7lmrshwzslfjv26-clang-wrapper-19.1.7"
+        "out": "/nix/store/vl936sd1vj8s008akm3gibkgyqk30qhz-clang-wrapper-21.1.8"
       },
       "system": "aarch64-darwin",
       "group": "toplevel",
@@ -948,27 +948,27 @@
     {
       "attr_path": "clang",
       "broken": false,
-      "derivation": "/nix/store/dwvs4irz4mdn0zbwp1kr6abkaysy77m6-clang-wrapper-19.1.7.drv",
+      "derivation": "/nix/store/dkb666rafg02z1zywadclydsaag2fy8k-clang-wrapper-21.1.8.drv",
       "description": "C language family frontend for LLVM (wrapper script)",
       "install_id": "clang",
       "license": "[ NCSA, Apache-2.0, LLVM-exception ]",
-      "locked_url": "https://github.com/flox/nixpkgs?rev=c23193b943c6c689d70ee98ce3128239ed9e32d1",
-      "name": "clang-wrapper-19.1.7",
+      "locked_url": "https://github.com/flox/nixpkgs?rev=aca4d95fce4914b3892661bcb80b8087293536c6",
+      "name": "clang-wrapper-21.1.8",
       "pname": "clang",
-      "rev": "c23193b943c6c689d70ee98ce3128239ed9e32d1",
-      "rev_count": 861038,
-      "rev_date": "2025-09-13T06:43:22Z",
-      "scrape_date": "2025-09-15T02:56:35.890352Z",
+      "rev": "aca4d95fce4914b3892661bcb80b8087293536c6",
+      "rev_count": 958961,
+      "rev_date": "2026-03-06T04:56:59Z",
+      "scrape_date": "2026-03-08T06:03:48.929131Z",
       "stabilities": [
         "unstable"
       ],
       "unfree": false,
-      "version": "19.1.7",
+      "version": "21.1.8",
       "outputs_to_install": [
         "out"
       ],
       "outputs": {
-        "out": "/nix/store/fk99cziyah7im2bahq2gw71cj90hwcq6-clang-wrapper-19.1.7"
+        "out": "/nix/store/q1843vmrs211i2xb1x16220jq1s3m1nz-clang-wrapper-21.1.8"
       },
       "system": "x86_64-darwin",
       "group": "toplevel",
@@ -977,30 +977,31 @@
     {
       "attr_path": "gcc",
       "broken": false,
-      "derivation": "/nix/store/xgd6sn2nbpk6p8hfkwfnaggapfa486id-gcc-wrapper-14.3.0.drv",
-      "description": "GNU Compiler Collection, version 14.3.0 (wrapper script)",
+      "derivation": "/nix/store/rwb9v0myg18sx7fn003h1ymla7fd4yay-gcc-wrapper-15.2.0.drv",
+      "description": "GNU Compiler Collection, version 15.2.0 (wrapper script)",
       "install_id": "gcc",
       "license": "GPL-3.0-or-later",
-      "locked_url": "https://github.com/flox/nixpkgs?rev=c23193b943c6c689d70ee98ce3128239ed9e32d1",
-      "name": "gcc-wrapper-14.3.0",
+      "locked_url": "https://github.com/flox/nixpkgs?rev=aca4d95fce4914b3892661bcb80b8087293536c6",
+      "name": "gcc-wrapper-15.2.0",
       "pname": "gcc",
-      "rev": "c23193b943c6c689d70ee98ce3128239ed9e32d1",
-      "rev_count": 861038,
-      "rev_date": "2025-09-13T06:43:22Z",
-      "scrape_date": "2025-09-15T02:29:41.456152Z",
+      "rev": "aca4d95fce4914b3892661bcb80b8087293536c6",
+      "rev_count": 958961,
+      "rev_date": "2026-03-06T04:56:59Z",
+      "scrape_date": "2026-03-08T05:23:25.387386Z",
       "stabilities": [
         "unstable"
       ],
       "unfree": false,
-      "version": "14.3.0",
+      "version": "15.2.0",
       "outputs_to_install": [
         "man",
+        "out",
         "out"
       ],
       "outputs": {
-        "info": "/nix/store/x2q2m245k44wxcskdknl5xdqrsya7fcy-gcc-wrapper-14.3.0-info",
-        "man": "/nix/store/f5k9bkq97gqc4ajmbavv3wxdwcqmng64-gcc-wrapper-14.3.0-man",
-        "out": "/nix/store/hf8w753nxqwkc5y5kjx33fx8fxw2dczp-gcc-wrapper-14.3.0"
+        "info": "/nix/store/0ps642kc7j7wg0bz3hb978plg16xfi7n-gcc-wrapper-15.2.0-info",
+        "man": "/nix/store/y50lsbpbiy4wg5ccbbb68rabs2n3m69b-gcc-wrapper-15.2.0-man",
+        "out": "/nix/store/6hazq450ci6m382yq4ym8a6mbiv9mfsk-gcc-wrapper-15.2.0"
       },
       "system": "aarch64-linux",
       "group": "toplevel",
@@ -1009,30 +1010,31 @@
     {
       "attr_path": "gcc",
       "broken": false,
-      "derivation": "/nix/store/i9kj1nhzkg91xsq8ny4z4hipl0b42kad-gcc-wrapper-14.3.0.drv",
-      "description": "GNU Compiler Collection, version 14.3.0 (wrapper script)",
+      "derivation": "/nix/store/l8kjykqqnkh48cxjhz1p9wh53mb65dpf-gcc-wrapper-15.2.0.drv",
+      "description": "GNU Compiler Collection, version 15.2.0 (wrapper script)",
       "install_id": "gcc",
       "license": "GPL-3.0-or-later",
-      "locked_url": "https://github.com/flox/nixpkgs?rev=c23193b943c6c689d70ee98ce3128239ed9e32d1",
-      "name": "gcc-wrapper-14.3.0",
+      "locked_url": "https://github.com/flox/nixpkgs?rev=aca4d95fce4914b3892661bcb80b8087293536c6",
+      "name": "gcc-wrapper-15.2.0",
       "pname": "gcc",
-      "rev": "c23193b943c6c689d70ee98ce3128239ed9e32d1",
-      "rev_count": 861038,
-      "rev_date": "2025-09-13T06:43:22Z",
-      "scrape_date": "2025-09-15T03:26:57.657160Z",
+      "rev": "aca4d95fce4914b3892661bcb80b8087293536c6",
+      "rev_count": 958961,
+      "rev_date": "2026-03-06T04:56:59Z",
+      "scrape_date": "2026-03-08T06:46:40.547323Z",
       "stabilities": [
         "unstable"
       ],
       "unfree": false,
-      "version": "14.3.0",
+      "version": "15.2.0",
       "outputs_to_install": [
         "man",
+        "out",
         "out"
       ],
       "outputs": {
-        "info": "/nix/store/12sy2qyk3qir1rg4jdrdnj91jaw50my2-gcc-wrapper-14.3.0-info",
-        "man": "/nix/store/ds5j2vvwhdvfgkjp7jnfx82bqswks46x-gcc-wrapper-14.3.0-man",
-        "out": "/nix/store/95k9rsn1zsw1yvir8mj824ldhf90i4qw-gcc-wrapper-14.3.0"
+        "info": "/nix/store/mj78x8b2vp0q9j6xf7bmvinn3m2csfhp-gcc-wrapper-15.2.0-info",
+        "man": "/nix/store/crcj0frpw4i8shmfwgyfx9fsqklf2iq5-gcc-wrapper-15.2.0-man",
+        "out": "/nix/store/kbw2j1vag664b3sj3rjwz9v53cqx87sb-gcc-wrapper-15.2.0"
       },
       "system": "x86_64-linux",
       "group": "toplevel",
@@ -1041,17 +1043,17 @@
     {
       "attr_path": "geckodriver",
       "broken": false,
-      "derivation": "/nix/store/j7faxmgfdi7bjcg1dfr4b8x51cxhb1cx-geckodriver-0.36.0.drv",
+      "derivation": "/nix/store/77y93j7dbflc6m756aggmg724hingddn-geckodriver-0.36.0.drv",
       "description": "Proxy for using W3C WebDriver-compatible clients to interact with Gecko-based browsers",
       "install_id": "geckodriver",
       "license": "MPL-2.0",
-      "locked_url": "https://github.com/flox/nixpkgs?rev=c23193b943c6c689d70ee98ce3128239ed9e32d1",
+      "locked_url": "https://github.com/flox/nixpkgs?rev=aca4d95fce4914b3892661bcb80b8087293536c6",
       "name": "geckodriver-0.36.0",
       "pname": "geckodriver",
-      "rev": "c23193b943c6c689d70ee98ce3128239ed9e32d1",
-      "rev_count": 861038,
-      "rev_date": "2025-09-13T06:43:22Z",
-      "scrape_date": "2025-09-15T02:00:43.192754Z",
+      "rev": "aca4d95fce4914b3892661bcb80b8087293536c6",
+      "rev_count": 958961,
+      "rev_date": "2026-03-06T04:56:59Z",
+      "scrape_date": "2026-03-08T04:46:44.125486Z",
       "stabilities": [
         "unstable"
       ],
@@ -1061,7 +1063,7 @@
         "out"
       ],
       "outputs": {
-        "out": "/nix/store/fln7sa7y95k4gsmpdxbp5jc8z1zd616v-geckodriver-0.36.0"
+        "out": "/nix/store/2r3xqj54kmh17iwf6rfj6bhs9pmc51dx-geckodriver-0.36.0"
       },
       "system": "aarch64-darwin",
       "group": "toplevel",
@@ -1070,17 +1072,17 @@
     {
       "attr_path": "geckodriver",
       "broken": false,
-      "derivation": "/nix/store/xsmi8px5vlzp1fn7y6mrfwvsj0qkwa2s-geckodriver-0.36.0.drv",
+      "derivation": "/nix/store/9nygx4n67sxsi17yikig11vvvmr3hz8x-geckodriver-0.36.0.drv",
       "description": "Proxy for using W3C WebDriver-compatible clients to interact with Gecko-based browsers",
       "install_id": "geckodriver",
       "license": "MPL-2.0",
-      "locked_url": "https://github.com/flox/nixpkgs?rev=c23193b943c6c689d70ee98ce3128239ed9e32d1",
+      "locked_url": "https://github.com/flox/nixpkgs?rev=aca4d95fce4914b3892661bcb80b8087293536c6",
       "name": "geckodriver-0.36.0",
       "pname": "geckodriver",
-      "rev": "c23193b943c6c689d70ee98ce3128239ed9e32d1",
-      "rev_count": 861038,
-      "rev_date": "2025-09-13T06:43:22Z",
-      "scrape_date": "2025-09-15T02:29:41.487494Z",
+      "rev": "aca4d95fce4914b3892661bcb80b8087293536c6",
+      "rev_count": 958961,
+      "rev_date": "2026-03-06T04:56:59Z",
+      "scrape_date": "2026-03-08T05:23:25.419159Z",
       "stabilities": [
         "unstable"
       ],
@@ -1090,7 +1092,7 @@
         "out"
       ],
       "outputs": {
-        "out": "/nix/store/xa61glap9q273blm0biw1p215sdmxi5s-geckodriver-0.36.0"
+        "out": "/nix/store/lvi3zlcqhhjvjhzk8hawsnp1i30ycia6-geckodriver-0.36.0"
       },
       "system": "aarch64-linux",
       "group": "toplevel",
@@ -1099,17 +1101,17 @@
     {
       "attr_path": "geckodriver",
       "broken": false,
-      "derivation": "/nix/store/mv0d1xn0gl8v79swq3b7l4a3pbzw3h87-geckodriver-0.36.0.drv",
+      "derivation": "/nix/store/qyzzxmsmp4kk7awgiyhq0lss3mb1kp1q-geckodriver-0.36.0.drv",
       "description": "Proxy for using W3C WebDriver-compatible clients to interact with Gecko-based browsers",
       "install_id": "geckodriver",
       "license": "MPL-2.0",
-      "locked_url": "https://github.com/flox/nixpkgs?rev=c23193b943c6c689d70ee98ce3128239ed9e32d1",
+      "locked_url": "https://github.com/flox/nixpkgs?rev=aca4d95fce4914b3892661bcb80b8087293536c6",
       "name": "geckodriver-0.36.0",
       "pname": "geckodriver",
-      "rev": "c23193b943c6c689d70ee98ce3128239ed9e32d1",
-      "rev_count": 861038,
-      "rev_date": "2025-09-13T06:43:22Z",
-      "scrape_date": "2025-09-15T02:56:36.581755Z",
+      "rev": "aca4d95fce4914b3892661bcb80b8087293536c6",
+      "rev_count": 958961,
+      "rev_date": "2026-03-06T04:56:59Z",
+      "scrape_date": "2026-03-08T06:03:49.696185Z",
       "stabilities": [
         "unstable"
       ],
@@ -1119,7 +1121,7 @@
         "out"
       ],
       "outputs": {
-        "out": "/nix/store/8xmp33w11sxfxigvhdsard9jk3y11xym-geckodriver-0.36.0"
+        "out": "/nix/store/0k3vqibdrlvc44rgknk60z68yvb0y19c-geckodriver-0.36.0"
       },
       "system": "x86_64-darwin",
       "group": "toplevel",
@@ -1128,17 +1130,17 @@
     {
       "attr_path": "geckodriver",
       "broken": false,
-      "derivation": "/nix/store/w66dmxwwrcx25vy3khz2fbg6aj2jqcbl-geckodriver-0.36.0.drv",
+      "derivation": "/nix/store/j3ldcd53gjmig4z0dixjps5nranjmqgz-geckodriver-0.36.0.drv",
       "description": "Proxy for using W3C WebDriver-compatible clients to interact with Gecko-based browsers",
       "install_id": "geckodriver",
       "license": "MPL-2.0",
-      "locked_url": "https://github.com/flox/nixpkgs?rev=c23193b943c6c689d70ee98ce3128239ed9e32d1",
+      "locked_url": "https://github.com/flox/nixpkgs?rev=aca4d95fce4914b3892661bcb80b8087293536c6",
       "name": "geckodriver-0.36.0",
       "pname": "geckodriver",
-      "rev": "c23193b943c6c689d70ee98ce3128239ed9e32d1",
-      "rev_count": 861038,
-      "rev_date": "2025-09-13T06:43:22Z",
-      "scrape_date": "2025-09-15T03:26:57.689208Z",
+      "rev": "aca4d95fce4914b3892661bcb80b8087293536c6",
+      "rev_count": 958961,
+      "rev_date": "2026-03-06T04:56:59Z",
+      "scrape_date": "2026-03-08T06:46:40.581799Z",
       "stabilities": [
         "unstable"
       ],
@@ -1148,7 +1150,7 @@
         "out"
       ],
       "outputs": {
-        "out": "/nix/store/2yv179fz74wwwwqv79xif9z4gjcllkfx-geckodriver-0.36.0"
+        "out": "/nix/store/ghb40j28z8npnbrgxkgirh72cj7gzxa2-geckodriver-0.36.0"
       },
       "system": "x86_64-linux",
       "group": "toplevel",
@@ -1157,28 +1159,28 @@
     {
       "attr_path": "git",
       "broken": false,
-      "derivation": "/nix/store/6d98i7ksgr6d4xjjh0y6fl6ianxxzzbf-git-2.51.0.drv",
+      "derivation": "/nix/store/s2i3mzap8yd2wh62kb7gvv2yi277p0rb-git-2.53.0.drv",
       "description": "Distributed version control system",
       "install_id": "git",
       "license": "GPL-2.0",
-      "locked_url": "https://github.com/flox/nixpkgs?rev=c23193b943c6c689d70ee98ce3128239ed9e32d1",
-      "name": "git-2.51.0",
+      "locked_url": "https://github.com/flox/nixpkgs?rev=aca4d95fce4914b3892661bcb80b8087293536c6",
+      "name": "git-2.53.0",
       "pname": "git",
-      "rev": "c23193b943c6c689d70ee98ce3128239ed9e32d1",
-      "rev_count": 861038,
-      "rev_date": "2025-09-13T06:43:22Z",
-      "scrape_date": "2025-09-15T02:00:43.250181Z",
+      "rev": "aca4d95fce4914b3892661bcb80b8087293536c6",
+      "rev_count": 958961,
+      "rev_date": "2026-03-06T04:56:59Z",
+      "scrape_date": "2026-03-08T04:46:44.186797Z",
       "stabilities": [
         "unstable"
       ],
       "unfree": false,
-      "version": "2.51.0",
+      "version": "2.53.0",
       "outputs_to_install": [
         "out"
       ],
       "outputs": {
-        "doc": "/nix/store/4gwi3dw7ay6ddmzyzx36a15ds51493hz-git-2.51.0-doc",
-        "out": "/nix/store/4q2dd3sf6xq9bky0aq2wyp2pf958j0rz-git-2.51.0"
+        "doc": "/nix/store/lgbyzfz2j1j7g47331i5684765akl38m-git-2.53.0-doc",
+        "out": "/nix/store/rfbzyqcygzpyh5ncb79n07x8bhws2pq3-git-2.53.0"
       },
       "system": "aarch64-darwin",
       "group": "toplevel",
@@ -1187,29 +1189,29 @@
     {
       "attr_path": "git",
       "broken": false,
-      "derivation": "/nix/store/jcd1hmakc99sfm5hzxgscpgkdhiq7bk4-git-2.51.0.drv",
+      "derivation": "/nix/store/49b1il02w5305g0qlc2pbqngq9ifdqb1-git-2.53.0.drv",
       "description": "Distributed version control system",
       "install_id": "git",
       "license": "GPL-2.0",
-      "locked_url": "https://github.com/flox/nixpkgs?rev=c23193b943c6c689d70ee98ce3128239ed9e32d1",
-      "name": "git-2.51.0",
+      "locked_url": "https://github.com/flox/nixpkgs?rev=aca4d95fce4914b3892661bcb80b8087293536c6",
+      "name": "git-2.53.0",
       "pname": "git",
-      "rev": "c23193b943c6c689d70ee98ce3128239ed9e32d1",
-      "rev_count": 861038,
-      "rev_date": "2025-09-13T06:43:22Z",
-      "scrape_date": "2025-09-15T02:29:41.582900Z",
+      "rev": "aca4d95fce4914b3892661bcb80b8087293536c6",
+      "rev_count": 958961,
+      "rev_date": "2026-03-06T04:56:59Z",
+      "scrape_date": "2026-03-08T05:23:25.514837Z",
       "stabilities": [
         "unstable"
       ],
       "unfree": false,
-      "version": "2.51.0",
+      "version": "2.53.0",
       "outputs_to_install": [
         "out"
       ],
       "outputs": {
-        "debug": "/nix/store/xh22pd5vdl2i1lj975gsv0dc4ywwi42j-git-2.51.0-debug",
-        "doc": "/nix/store/lxbmn3fzikq9l7aw4xi6lkxqmc2866qd-git-2.51.0-doc",
-        "out": "/nix/store/7x5qzsv0msjcvyhn98zayq520gdwb76m-git-2.51.0"
+        "debug": "/nix/store/xr7sgggqixdji66nhax03lwmk25ms7af-git-2.53.0-debug",
+        "doc": "/nix/store/lspm2ph3iad5y9irmh2wms6bm3nhhy76-git-2.53.0-doc",
+        "out": "/nix/store/xz8bzpl5fz92bkhcdmf4g45znvvzcakd-git-2.53.0"
       },
       "system": "aarch64-linux",
       "group": "toplevel",
@@ -1218,28 +1220,28 @@
     {
       "attr_path": "git",
       "broken": false,
-      "derivation": "/nix/store/wqvqcz0zhylgjfzgbw22dkn9ms5slzda-git-2.51.0.drv",
+      "derivation": "/nix/store/0ykc7k2974j1m627pcbv307ra2qvrzmr-git-2.53.0.drv",
       "description": "Distributed version control system",
       "install_id": "git",
       "license": "GPL-2.0",
-      "locked_url": "https://github.com/flox/nixpkgs?rev=c23193b943c6c689d70ee98ce3128239ed9e32d1",
-      "name": "git-2.51.0",
+      "locked_url": "https://github.com/flox/nixpkgs?rev=aca4d95fce4914b3892661bcb80b8087293536c6",
+      "name": "git-2.53.0",
       "pname": "git",
-      "rev": "c23193b943c6c689d70ee98ce3128239ed9e32d1",
-      "rev_count": 861038,
-      "rev_date": "2025-09-13T06:43:22Z",
-      "scrape_date": "2025-09-15T02:56:36.641268Z",
+      "rev": "aca4d95fce4914b3892661bcb80b8087293536c6",
+      "rev_count": 958961,
+      "rev_date": "2026-03-06T04:56:59Z",
+      "scrape_date": "2026-03-08T06:03:49.758372Z",
       "stabilities": [
         "unstable"
       ],
       "unfree": false,
-      "version": "2.51.0",
+      "version": "2.53.0",
       "outputs_to_install": [
         "out"
       ],
       "outputs": {
-        "doc": "/nix/store/6mrf4pn3qr89l7lw1xv2n5nlj0wpqs94-git-2.51.0-doc",
-        "out": "/nix/store/a16jim5gw87lhmzms8n9jvz6rqii52n1-git-2.51.0"
+        "doc": "/nix/store/0wx1wdjy7imyv7cp6p6m2l17ycq7n3q4-git-2.53.0-doc",
+        "out": "/nix/store/bmddbpv896f9rgnm0835434qjiqh1psc-git-2.53.0"
       },
       "system": "x86_64-darwin",
       "group": "toplevel",
@@ -1248,29 +1250,29 @@
     {
       "attr_path": "git",
       "broken": false,
-      "derivation": "/nix/store/yyw6nzfcdckb36blm5mf5b5mss1m9asq-git-2.51.0.drv",
+      "derivation": "/nix/store/fnrzknhph15x5iv4ii5x1wl722x311ha-git-2.53.0.drv",
       "description": "Distributed version control system",
       "install_id": "git",
       "license": "GPL-2.0",
-      "locked_url": "https://github.com/flox/nixpkgs?rev=c23193b943c6c689d70ee98ce3128239ed9e32d1",
-      "name": "git-2.51.0",
+      "locked_url": "https://github.com/flox/nixpkgs?rev=aca4d95fce4914b3892661bcb80b8087293536c6",
+      "name": "git-2.53.0",
       "pname": "git",
-      "rev": "c23193b943c6c689d70ee98ce3128239ed9e32d1",
-      "rev_count": 861038,
-      "rev_date": "2025-09-13T06:43:22Z",
-      "scrape_date": "2025-09-15T03:26:57.785953Z",
+      "rev": "aca4d95fce4914b3892661bcb80b8087293536c6",
+      "rev_count": 958961,
+      "rev_date": "2026-03-06T04:56:59Z",
+      "scrape_date": "2026-03-08T06:46:40.686647Z",
       "stabilities": [
         "unstable"
       ],
       "unfree": false,
-      "version": "2.51.0",
+      "version": "2.53.0",
       "outputs_to_install": [
         "out"
       ],
       "outputs": {
-        "debug": "/nix/store/zdh0b77j1n8irhshwgrhyjfrrjxk9fbw-git-2.51.0-debug",
-        "doc": "/nix/store/vjjhqc2vixs1pfy4bh5qpqrvqg042vd4-git-2.51.0-doc",
-        "out": "/nix/store/q1zaii9cirbfpmwr7d86hpppql3kjcpf-git-2.51.0"
+        "debug": "/nix/store/i9fi7yqx2z2dryn80w5pr4b1v4nmyida-git-2.53.0-debug",
+        "doc": "/nix/store/frqc9w8q0dxsg7b8w3j0cv1lb9bd6xww-git-2.53.0-doc",
+        "out": "/nix/store/8x49w8i0vafv34rlc6h4a0f7z0z2qpb5-git-2.53.0"
       },
       "system": "x86_64-linux",
       "group": "toplevel",
@@ -1279,17 +1281,17 @@
     {
       "attr_path": "gum",
       "broken": false,
-      "derivation": "/nix/store/i7da40pyfvk25xwk2xkg7rlzv3zqf4s3-gum-0.17.0.drv",
+      "derivation": "/nix/store/zylkfcv4g5sgxgc7h6fh4qry05s7h68k-gum-0.17.0.drv",
       "description": "Tasty Bubble Gum for your shell",
       "install_id": "gum",
       "license": "MIT",
-      "locked_url": "https://github.com/flox/nixpkgs?rev=c23193b943c6c689d70ee98ce3128239ed9e32d1",
+      "locked_url": "https://github.com/flox/nixpkgs?rev=aca4d95fce4914b3892661bcb80b8087293536c6",
       "name": "gum-0.17.0",
       "pname": "gum",
-      "rev": "c23193b943c6c689d70ee98ce3128239ed9e32d1",
-      "rev_count": 861038,
-      "rev_date": "2025-09-13T06:43:22Z",
-      "scrape_date": "2025-09-15T02:00:44.120342Z",
+      "rev": "aca4d95fce4914b3892661bcb80b8087293536c6",
+      "rev_count": 958961,
+      "rev_date": "2026-03-06T04:56:59Z",
+      "scrape_date": "2026-03-08T04:46:44.535336Z",
       "stabilities": [
         "unstable"
       ],
@@ -1299,7 +1301,7 @@
         "out"
       ],
       "outputs": {
-        "out": "/nix/store/6acx1nn0f2i5v6dkdzaap2hdngkp1lpz-gum-0.17.0"
+        "out": "/nix/store/x5ngj85sp5paq6la0g60qrx7p6z6h9iz-gum-0.17.0"
       },
       "system": "aarch64-darwin",
       "group": "toplevel",
@@ -1308,17 +1310,17 @@
     {
       "attr_path": "gum",
       "broken": false,
-      "derivation": "/nix/store/vn184rxp6dqbd1lacq122him8nif1ljj-gum-0.17.0.drv",
+      "derivation": "/nix/store/askwy3zh15vrpclpxspxvbgybypd7pdg-gum-0.17.0.drv",
       "description": "Tasty Bubble Gum for your shell",
       "install_id": "gum",
       "license": "MIT",
-      "locked_url": "https://github.com/flox/nixpkgs?rev=c23193b943c6c689d70ee98ce3128239ed9e32d1",
+      "locked_url": "https://github.com/flox/nixpkgs?rev=aca4d95fce4914b3892661bcb80b8087293536c6",
       "name": "gum-0.17.0",
       "pname": "gum",
-      "rev": "c23193b943c6c689d70ee98ce3128239ed9e32d1",
-      "rev_count": 861038,
-      "rev_date": "2025-09-13T06:43:22Z",
-      "scrape_date": "2025-09-15T02:29:42.434628Z",
+      "rev": "aca4d95fce4914b3892661bcb80b8087293536c6",
+      "rev_count": 958961,
+      "rev_date": "2026-03-06T04:56:59Z",
+      "scrape_date": "2026-03-08T05:23:26.568425Z",
       "stabilities": [
         "unstable"
       ],
@@ -1328,7 +1330,7 @@
         "out"
       ],
       "outputs": {
-        "out": "/nix/store/caisq1py34nrn7q3lx4sswkm0zlpdr4n-gum-0.17.0"
+        "out": "/nix/store/8492ypc20ys8kghyq4c9n8bfip85rg0n-gum-0.17.0"
       },
       "system": "aarch64-linux",
       "group": "toplevel",
@@ -1337,17 +1339,17 @@
     {
       "attr_path": "gum",
       "broken": false,
-      "derivation": "/nix/store/xzwzl56m1rwcb5pbmq85cvhyhfd1angc-gum-0.17.0.drv",
+      "derivation": "/nix/store/31fgwkf0zw1hphyak75bpj6js1ywz30a-gum-0.17.0.drv",
       "description": "Tasty Bubble Gum for your shell",
       "install_id": "gum",
       "license": "MIT",
-      "locked_url": "https://github.com/flox/nixpkgs?rev=c23193b943c6c689d70ee98ce3128239ed9e32d1",
+      "locked_url": "https://github.com/flox/nixpkgs?rev=aca4d95fce4914b3892661bcb80b8087293536c6",
       "name": "gum-0.17.0",
       "pname": "gum",
-      "rev": "c23193b943c6c689d70ee98ce3128239ed9e32d1",
-      "rev_count": 861038,
-      "rev_date": "2025-09-13T06:43:22Z",
-      "scrape_date": "2025-09-15T02:56:36.984532Z",
+      "rev": "aca4d95fce4914b3892661bcb80b8087293536c6",
+      "rev_count": 958961,
+      "rev_date": "2026-03-06T04:56:59Z",
+      "scrape_date": "2026-03-08T06:03:50.133747Z",
       "stabilities": [
         "unstable"
       ],
@@ -1357,7 +1359,7 @@
         "out"
       ],
       "outputs": {
-        "out": "/nix/store/w467h914divp2k8qyk5x14hci2jm7ww6-gum-0.17.0"
+        "out": "/nix/store/948mlcmz4vhy43ij44iw86gcazb6j7bq-gum-0.17.0"
       },
       "system": "x86_64-darwin",
       "group": "toplevel",
@@ -1366,17 +1368,17 @@
     {
       "attr_path": "gum",
       "broken": false,
-      "derivation": "/nix/store/3l47qcfk0x158cx0f3ql2pggnxgd6v9p-gum-0.17.0.drv",
+      "derivation": "/nix/store/2wypa77mpv3kv90gj5v047sgafnhj540-gum-0.17.0.drv",
       "description": "Tasty Bubble Gum for your shell",
       "install_id": "gum",
       "license": "MIT",
-      "locked_url": "https://github.com/flox/nixpkgs?rev=c23193b943c6c689d70ee98ce3128239ed9e32d1",
+      "locked_url": "https://github.com/flox/nixpkgs?rev=aca4d95fce4914b3892661bcb80b8087293536c6",
       "name": "gum-0.17.0",
       "pname": "gum",
-      "rev": "c23193b943c6c689d70ee98ce3128239ed9e32d1",
-      "rev_count": 861038,
-      "rev_date": "2025-09-13T06:43:22Z",
-      "scrape_date": "2025-09-15T03:26:58.732150Z",
+      "rev": "aca4d95fce4914b3892661bcb80b8087293536c6",
+      "rev_count": 958961,
+      "rev_date": "2026-03-06T04:56:59Z",
+      "scrape_date": "2026-03-08T06:46:41.812407Z",
       "stabilities": [
         "unstable"
       ],
@@ -1386,7 +1388,7 @@
         "out"
       ],
       "outputs": {
-        "out": "/nix/store/jbjrj4hbf2bgdvr6vl4dalwn31s669p4-gum-0.17.0"
+        "out": "/nix/store/x5bn6qhx5qr16w5nz0mh5bh9ww4530h8-gum-0.17.0"
       },
       "system": "x86_64-linux",
       "group": "toplevel",
@@ -1395,30 +1397,30 @@
     {
       "attr_path": "just",
       "broken": false,
-      "derivation": "/nix/store/khsgi9byqrl5m1navqcfv1701zc0zlcg-just-1.42.4.drv",
+      "derivation": "/nix/store/hqzsm06rmk6sbh8dy1k0a8cwcv4qa900-just-1.46.0.drv",
       "description": "Handy way to save and run project-specific commands",
       "install_id": "just",
       "license": "CC0-1.0",
-      "locked_url": "https://github.com/flox/nixpkgs?rev=c23193b943c6c689d70ee98ce3128239ed9e32d1",
-      "name": "just-1.42.4",
+      "locked_url": "https://github.com/flox/nixpkgs?rev=aca4d95fce4914b3892661bcb80b8087293536c6",
+      "name": "just-1.46.0",
       "pname": "just",
-      "rev": "c23193b943c6c689d70ee98ce3128239ed9e32d1",
-      "rev_count": 861038,
-      "rev_date": "2025-09-13T06:43:22Z",
-      "scrape_date": "2025-09-15T02:00:57.911808Z",
+      "rev": "aca4d95fce4914b3892661bcb80b8087293536c6",
+      "rev_count": 958961,
+      "rev_date": "2026-03-06T04:56:59Z",
+      "scrape_date": "2026-03-08T04:46:59.352073Z",
       "stabilities": [
         "unstable"
       ],
       "unfree": false,
-      "version": "1.42.4",
+      "version": "1.46.0",
       "outputs_to_install": [
         "man",
         "out"
       ],
       "outputs": {
-        "doc": "/nix/store/8xavlkm9j3xx4qllzmy5f45fzv9xfb67-just-1.42.4-doc",
-        "man": "/nix/store/ckppkxqp5ip8kaprwbr7x2d9a5qmrcwf-just-1.42.4-man",
-        "out": "/nix/store/ybxppkvhr3k3ssqhbgccmha29dkgk8f7-just-1.42.4"
+        "doc": "/nix/store/z9xkrp3wmnlhf9h9s1jsh4r23w9jnjj1-just-1.46.0-doc",
+        "man": "/nix/store/0rf7kvb3b5pz82rwadn4xm8y77x2iy4q-just-1.46.0-man",
+        "out": "/nix/store/70xj73qsinvmbc3rn1rch3k0bk2ric41-just-1.46.0"
       },
       "system": "aarch64-darwin",
       "group": "toplevel",
@@ -1427,30 +1429,30 @@
     {
       "attr_path": "just",
       "broken": false,
-      "derivation": "/nix/store/8xb1yvd8qd4w1pl7dbd8ds9g8l84w0pc-just-1.42.4.drv",
+      "derivation": "/nix/store/s62jy5fz1xsz5ay2sdc9sy139jm2nzy8-just-1.46.0.drv",
       "description": "Handy way to save and run project-specific commands",
       "install_id": "just",
       "license": "CC0-1.0",
-      "locked_url": "https://github.com/flox/nixpkgs?rev=c23193b943c6c689d70ee98ce3128239ed9e32d1",
-      "name": "just-1.42.4",
+      "locked_url": "https://github.com/flox/nixpkgs?rev=aca4d95fce4914b3892661bcb80b8087293536c6",
+      "name": "just-1.46.0",
       "pname": "just",
-      "rev": "c23193b943c6c689d70ee98ce3128239ed9e32d1",
-      "rev_count": 861038,
-      "rev_date": "2025-09-13T06:43:22Z",
-      "scrape_date": "2025-09-15T02:30:01.004804Z",
+      "rev": "aca4d95fce4914b3892661bcb80b8087293536c6",
+      "rev_count": 958961,
+      "rev_date": "2026-03-06T04:56:59Z",
+      "scrape_date": "2026-03-08T05:23:45.423481Z",
       "stabilities": [
         "unstable"
       ],
       "unfree": false,
-      "version": "1.42.4",
+      "version": "1.46.0",
       "outputs_to_install": [
         "man",
         "out"
       ],
       "outputs": {
-        "doc": "/nix/store/fwfx6fh2cai9rfkfps9swh9wq593n0aa-just-1.42.4-doc",
-        "man": "/nix/store/7czcmnfirfmsh2qihr6far9jiq9a8542-just-1.42.4-man",
-        "out": "/nix/store/czphzid3fs3bp8afmq1jhidz2cvrrnsd-just-1.42.4"
+        "doc": "/nix/store/4qwqc5rhwj795kqk6385l97paqpvhlaf-just-1.46.0-doc",
+        "man": "/nix/store/sykdbhkkadkdgx0psdm3q1j2zpcqm7nn-just-1.46.0-man",
+        "out": "/nix/store/429xi40vq2by0f8qibrj8w45n92mkhzf-just-1.46.0"
       },
       "system": "aarch64-linux",
       "group": "toplevel",
@@ -1459,30 +1461,30 @@
     {
       "attr_path": "just",
       "broken": false,
-      "derivation": "/nix/store/k5k4znc31dxz214yfi4b2zpd2fdwm0lv-just-1.42.4.drv",
+      "derivation": "/nix/store/fasgf0pa6cpgjdn87b0aysbj7d3qdz8l-just-1.46.0.drv",
       "description": "Handy way to save and run project-specific commands",
       "install_id": "just",
       "license": "CC0-1.0",
-      "locked_url": "https://github.com/flox/nixpkgs?rev=c23193b943c6c689d70ee98ce3128239ed9e32d1",
-      "name": "just-1.42.4",
+      "locked_url": "https://github.com/flox/nixpkgs?rev=aca4d95fce4914b3892661bcb80b8087293536c6",
+      "name": "just-1.46.0",
       "pname": "just",
-      "rev": "c23193b943c6c689d70ee98ce3128239ed9e32d1",
-      "rev_count": 861038,
-      "rev_date": "2025-09-13T06:43:22Z",
-      "scrape_date": "2025-09-15T02:56:50.891036Z",
+      "rev": "aca4d95fce4914b3892661bcb80b8087293536c6",
+      "rev_count": 958961,
+      "rev_date": "2026-03-06T04:56:59Z",
+      "scrape_date": "2026-03-08T06:04:05.079172Z",
       "stabilities": [
         "unstable"
       ],
       "unfree": false,
-      "version": "1.42.4",
+      "version": "1.46.0",
       "outputs_to_install": [
         "man",
         "out"
       ],
       "outputs": {
-        "doc": "/nix/store/d97hjbj7hjawid5kslhyijkpaha4fq2l-just-1.42.4-doc",
-        "man": "/nix/store/p2jp63pc1wdlb55j11frh1r9z4fvzsp5-just-1.42.4-man",
-        "out": "/nix/store/ii2mcj182bl1y6h1qhz28rpidpi9wzhy-just-1.42.4"
+        "doc": "/nix/store/7hjj4qlvv9kk7rwj3gwz7pyxy6sc8p74-just-1.46.0-doc",
+        "man": "/nix/store/ii6487zmcpc6qf5v95pfw646f8smkf87-just-1.46.0-man",
+        "out": "/nix/store/2ai2169px8hbs6ap7srh9240v7qarjrl-just-1.46.0"
       },
       "system": "x86_64-darwin",
       "group": "toplevel",
@@ -1491,30 +1493,30 @@
     {
       "attr_path": "just",
       "broken": false,
-      "derivation": "/nix/store/qjnl20dvbzzanbsjkhyf09njv8mfqcy4-just-1.42.4.drv",
+      "derivation": "/nix/store/li38aamrnf2k4p471886bw4i88391kc7-just-1.46.0.drv",
       "description": "Handy way to save and run project-specific commands",
       "install_id": "just",
       "license": "CC0-1.0",
-      "locked_url": "https://github.com/flox/nixpkgs?rev=c23193b943c6c689d70ee98ce3128239ed9e32d1",
-      "name": "just-1.42.4",
+      "locked_url": "https://github.com/flox/nixpkgs?rev=aca4d95fce4914b3892661bcb80b8087293536c6",
+      "name": "just-1.46.0",
       "pname": "just",
-      "rev": "c23193b943c6c689d70ee98ce3128239ed9e32d1",
-      "rev_count": 861038,
-      "rev_date": "2025-09-13T06:43:22Z",
-      "scrape_date": "2025-09-15T03:27:18.029952Z",
+      "rev": "aca4d95fce4914b3892661bcb80b8087293536c6",
+      "rev_count": 958961,
+      "rev_date": "2026-03-06T04:56:59Z",
+      "scrape_date": "2026-03-08T06:47:01.074387Z",
       "stabilities": [
         "unstable"
       ],
       "unfree": false,
-      "version": "1.42.4",
+      "version": "1.46.0",
       "outputs_to_install": [
         "man",
         "out"
       ],
       "outputs": {
-        "doc": "/nix/store/f3q8pxx7sl7nkw3p9c63j60nwvcn50rj-just-1.42.4-doc",
-        "man": "/nix/store/7qdcpikn194jivbgn84iizvr7cmpk0hb-just-1.42.4-man",
-        "out": "/nix/store/i5l66qbwry5skvwac6zxi81xq6qa3qwr-just-1.42.4"
+        "doc": "/nix/store/hd32nmf13rby52cd7g5gw6f3p2ghnrhl-just-1.46.0-doc",
+        "man": "/nix/store/n15hvaaz1fmrl0fgypqr04yj6mj825rw-just-1.46.0-man",
+        "out": "/nix/store/x6bvf2yyik9jlp2bdsdh8hbzg4l9sd49-just-1.46.0"
       },
       "system": "x86_64-linux",
       "group": "toplevel",
@@ -1523,17 +1525,17 @@
     {
       "attr_path": "leptosfmt",
       "broken": false,
-      "derivation": "/nix/store/k7sbncbfd4g3wlhryyg1yqg03dx8nzav-leptosfmt-0.1.33.drv",
+      "derivation": "/nix/store/0q3rn5imbhrf3c252nw362p0jknf04vl-leptosfmt-0.1.33.drv",
       "description": "Formatter for the leptos view! macro",
       "install_id": "leptosfmt",
       "license": "[ Apache-2.0, MIT ]",
-      "locked_url": "https://github.com/flox/nixpkgs?rev=c23193b943c6c689d70ee98ce3128239ed9e32d1",
+      "locked_url": "https://github.com/flox/nixpkgs?rev=aca4d95fce4914b3892661bcb80b8087293536c6",
       "name": "leptosfmt-0.1.33",
       "pname": "leptosfmt",
-      "rev": "c23193b943c6c689d70ee98ce3128239ed9e32d1",
-      "rev_count": 861038,
-      "rev_date": "2025-09-13T06:43:22Z",
-      "scrape_date": "2025-09-15T02:00:58.774368Z",
+      "rev": "aca4d95fce4914b3892661bcb80b8087293536c6",
+      "rev_count": 958961,
+      "rev_date": "2026-03-06T04:56:59Z",
+      "scrape_date": "2026-03-08T04:47:00.233291Z",
       "stabilities": [
         "unstable"
       ],
@@ -1543,7 +1545,7 @@
         "out"
       ],
       "outputs": {
-        "out": "/nix/store/w7mxvjzcp2hhf9a4ibircd36clrf2z6b-leptosfmt-0.1.33"
+        "out": "/nix/store/1fbmbgxppqgxpy4i17kj6d9vnwhhq1g3-leptosfmt-0.1.33"
       },
       "system": "aarch64-darwin",
       "group": "toplevel",
@@ -1552,17 +1554,17 @@
     {
       "attr_path": "leptosfmt",
       "broken": false,
-      "derivation": "/nix/store/0bj79kwkks7swaf1z29a52frwkqdxxyz-leptosfmt-0.1.33.drv",
+      "derivation": "/nix/store/968kbhb5mrqzjspz6wgip6h3kpa2cjbs-leptosfmt-0.1.33.drv",
       "description": "Formatter for the leptos view! macro",
       "install_id": "leptosfmt",
       "license": "[ Apache-2.0, MIT ]",
-      "locked_url": "https://github.com/flox/nixpkgs?rev=c23193b943c6c689d70ee98ce3128239ed9e32d1",
+      "locked_url": "https://github.com/flox/nixpkgs?rev=aca4d95fce4914b3892661bcb80b8087293536c6",
       "name": "leptosfmt-0.1.33",
       "pname": "leptosfmt",
-      "rev": "c23193b943c6c689d70ee98ce3128239ed9e32d1",
-      "rev_count": 861038,
-      "rev_date": "2025-09-13T06:43:22Z",
-      "scrape_date": "2025-09-15T02:30:02.966230Z",
+      "rev": "aca4d95fce4914b3892661bcb80b8087293536c6",
+      "rev_count": 958961,
+      "rev_date": "2026-03-06T04:56:59Z",
+      "scrape_date": "2026-03-08T05:23:47.424962Z",
       "stabilities": [
         "unstable"
       ],
@@ -1572,7 +1574,7 @@
         "out"
       ],
       "outputs": {
-        "out": "/nix/store/c2h24xyf2kn1yl5qvf413hmmflwy2g70-leptosfmt-0.1.33"
+        "out": "/nix/store/s3ismixg37hdipxbi2gcs0ddgmsjqhyl-leptosfmt-0.1.33"
       },
       "system": "aarch64-linux",
       "group": "toplevel",
@@ -1581,17 +1583,17 @@
     {
       "attr_path": "leptosfmt",
       "broken": false,
-      "derivation": "/nix/store/grgxwf0yvq6k9v8ls4q748nyzhxnzb2m-leptosfmt-0.1.33.drv",
+      "derivation": "/nix/store/44mc1q8yknmik4ycck00ag44cd5szzni-leptosfmt-0.1.33.drv",
       "description": "Formatter for the leptos view! macro",
       "install_id": "leptosfmt",
       "license": "[ Apache-2.0, MIT ]",
-      "locked_url": "https://github.com/flox/nixpkgs?rev=c23193b943c6c689d70ee98ce3128239ed9e32d1",
+      "locked_url": "https://github.com/flox/nixpkgs?rev=aca4d95fce4914b3892661bcb80b8087293536c6",
       "name": "leptosfmt-0.1.33",
       "pname": "leptosfmt",
-      "rev": "c23193b943c6c689d70ee98ce3128239ed9e32d1",
-      "rev_count": 861038,
-      "rev_date": "2025-09-13T06:43:22Z",
-      "scrape_date": "2025-09-15T02:56:51.755081Z",
+      "rev": "aca4d95fce4914b3892661bcb80b8087293536c6",
+      "rev_count": 958961,
+      "rev_date": "2026-03-06T04:56:59Z",
+      "scrape_date": "2026-03-08T06:04:05.997060Z",
       "stabilities": [
         "unstable"
       ],
@@ -1601,7 +1603,7 @@
         "out"
       ],
       "outputs": {
-        "out": "/nix/store/q62z3rlzjb1v1vqidgp5f687p6sr329a-leptosfmt-0.1.33"
+        "out": "/nix/store/q05r82bm5vlms1ccf11dcapv2bzkg45l-leptosfmt-0.1.33"
       },
       "system": "x86_64-darwin",
       "group": "toplevel",
@@ -1610,17 +1612,17 @@
     {
       "attr_path": "leptosfmt",
       "broken": false,
-      "derivation": "/nix/store/sks13fhzxz2d7kvnmi20pb25ymv8ha7a-leptosfmt-0.1.33.drv",
+      "derivation": "/nix/store/yi0pi7l06m465ndcxa7dmpclmslxj9qc-leptosfmt-0.1.33.drv",
       "description": "Formatter for the leptos view! macro",
       "install_id": "leptosfmt",
       "license": "[ Apache-2.0, MIT ]",
-      "locked_url": "https://github.com/flox/nixpkgs?rev=c23193b943c6c689d70ee98ce3128239ed9e32d1",
+      "locked_url": "https://github.com/flox/nixpkgs?rev=aca4d95fce4914b3892661bcb80b8087293536c6",
       "name": "leptosfmt-0.1.33",
       "pname": "leptosfmt",
-      "rev": "c23193b943c6c689d70ee98ce3128239ed9e32d1",
-      "rev_count": 861038,
-      "rev_date": "2025-09-13T06:43:22Z",
-      "scrape_date": "2025-09-15T03:27:20.040066Z",
+      "rev": "aca4d95fce4914b3892661bcb80b8087293536c6",
+      "rev_count": 958961,
+      "rev_date": "2026-03-06T04:56:59Z",
+      "scrape_date": "2026-03-08T06:47:03.232287Z",
       "stabilities": [
         "unstable"
       ],
@@ -1630,7 +1632,7 @@
         "out"
       ],
       "outputs": {
-        "out": "/nix/store/gxjkhdmbaa09y32nhq8j9nk9dc36mvd5-leptosfmt-0.1.33"
+        "out": "/nix/store/j39qwd1srbq50x4n25jdzx9k0c360v9d-leptosfmt-0.1.33"
       },
       "system": "x86_64-linux",
       "group": "toplevel",
@@ -1639,28 +1641,30 @@
     {
       "attr_path": "libiconv",
       "broken": false,
-      "derivation": "/nix/store/d21w5kgpc8829hzmmhfcw7iq5fndkv3h-libiconv-109.drv",
+      "derivation": "/nix/store/bd6i4rxawyi8v3055xrqppmh8b391yrx-libiconv-109.100.2.drv",
       "description": "Iconv(3) implementation",
       "install_id": "libiconv",
       "license": "[ BSD-2-Clause, BSD-3-Clause, APSL-1.0 ]",
-      "locked_url": "https://github.com/flox/nixpkgs?rev=c23193b943c6c689d70ee98ce3128239ed9e32d1",
-      "name": "libiconv-109",
+      "locked_url": "https://github.com/flox/nixpkgs?rev=aca4d95fce4914b3892661bcb80b8087293536c6",
+      "name": "libiconv-109.100.2",
       "pname": "libiconv",
-      "rev": "c23193b943c6c689d70ee98ce3128239ed9e32d1",
-      "rev_count": 861038,
-      "rev_date": "2025-09-13T06:43:22Z",
-      "scrape_date": "2025-09-15T02:00:59.125319Z",
+      "rev": "aca4d95fce4914b3892661bcb80b8087293536c6",
+      "rev_count": 958961,
+      "rev_date": "2026-03-06T04:56:59Z",
+      "scrape_date": "2026-03-08T04:47:00.634208Z",
       "stabilities": [
         "unstable"
       ],
       "unfree": false,
-      "version": "109",
+      "version": "109.100.2",
       "outputs_to_install": [
+        "out",
+        "out",
         "out"
       ],
       "outputs": {
-        "dev": "/nix/store/7s8gizw7d3hw8wyf7npayp5dk47727mz-libiconv-109-dev",
-        "out": "/nix/store/clci1zxqwa39qp135b1lfbbwad9qa4g0-libiconv-109"
+        "dev": "/nix/store/gkyk559bh4zzxh0wfvzqi6zj3rdn0d9q-libiconv-109.100.2-dev",
+        "out": "/nix/store/ik1b3z19bgk8lagf461zq222kxrpdynb-libiconv-109.100.2"
       },
       "system": "aarch64-darwin",
       "group": "toplevel",
@@ -1669,28 +1673,28 @@
     {
       "attr_path": "libiconv",
       "broken": false,
-      "derivation": "/nix/store/zsbd141b7rq2639c2lq5xsn0xcdc9i9s-libiconv-109.drv",
+      "derivation": "/nix/store/9xwr5ga8nsadiiyh7y24azwgv9haflz8-libiconv-109.100.2.drv",
       "description": "Iconv(3) implementation",
       "install_id": "libiconv",
       "license": "[ BSD-2-Clause, BSD-3-Clause, APSL-1.0 ]",
-      "locked_url": "https://github.com/flox/nixpkgs?rev=c23193b943c6c689d70ee98ce3128239ed9e32d1",
-      "name": "libiconv-109",
+      "locked_url": "https://github.com/flox/nixpkgs?rev=aca4d95fce4914b3892661bcb80b8087293536c6",
+      "name": "libiconv-109.100.2",
       "pname": "libiconv",
-      "rev": "c23193b943c6c689d70ee98ce3128239ed9e32d1",
-      "rev_count": 861038,
-      "rev_date": "2025-09-13T06:43:22Z",
-      "scrape_date": "2025-09-15T02:56:52.096823Z",
+      "rev": "aca4d95fce4914b3892661bcb80b8087293536c6",
+      "rev_count": 958961,
+      "rev_date": "2026-03-06T04:56:59Z",
+      "scrape_date": "2026-03-08T06:04:06.406088Z",
       "stabilities": [
         "unstable"
       ],
       "unfree": false,
-      "version": "109",
+      "version": "109.100.2",
       "outputs_to_install": [
         "out"
       ],
       "outputs": {
-        "dev": "/nix/store/sqrlc5n1sar9aynzqym3gbm2p98hx7cn-libiconv-109-dev",
-        "out": "/nix/store/4idh8sgmy2wafmvmbab8dw0053jgwr8c-libiconv-109"
+        "dev": "/nix/store/5bwhjr63kxw3vbjs3qi03nw43xl4cvy0-libiconv-109.100.2-dev",
+        "out": "/nix/store/m6k3gjsdqrnjyrakkv7005lpf33zxj9f-libiconv-109.100.2"
       },
       "system": "x86_64-darwin",
       "group": "toplevel",
@@ -1699,29 +1703,29 @@
     {
       "attr_path": "lld",
       "broken": false,
-      "derivation": "/nix/store/g88dh4lb7mkd841bgnfai716pmxv5s03-lld-19.1.7.drv",
+      "derivation": "/nix/store/a6q8hpzllpc0rybbd323mmsn08rcbyn5-lld-21.1.8.drv",
       "description": "LLVM linker (unwrapped)",
       "install_id": "lld",
       "license": "[ NCSA, Apache-2.0, LLVM-exception ]",
-      "locked_url": "https://github.com/flox/nixpkgs?rev=c23193b943c6c689d70ee98ce3128239ed9e32d1",
-      "name": "lld-19.1.7",
+      "locked_url": "https://github.com/flox/nixpkgs?rev=aca4d95fce4914b3892661bcb80b8087293536c6",
+      "name": "lld-21.1.8",
       "pname": "lld",
-      "rev": "c23193b943c6c689d70ee98ce3128239ed9e32d1",
-      "rev_count": 861038,
-      "rev_date": "2025-09-13T06:43:22Z",
-      "scrape_date": "2025-09-15T02:01:00.238728Z",
+      "rev": "aca4d95fce4914b3892661bcb80b8087293536c6",
+      "rev_count": 958961,
+      "rev_date": "2026-03-06T04:56:59Z",
+      "scrape_date": "2026-03-08T04:47:01.877744Z",
       "stabilities": [
         "unstable"
       ],
       "unfree": false,
-      "version": "19.1.7",
+      "version": "21.1.8",
       "outputs_to_install": [
         "out"
       ],
       "outputs": {
-        "dev": "/nix/store/ya6cjjrxpf54j88v7187xbz087zjhcg6-lld-19.1.7-dev",
-        "lib": "/nix/store/za4x3c5r6yw61lk1nqpc5nrw5mdlzilv-lld-19.1.7-lib",
-        "out": "/nix/store/6srv6jv1wfjp1wkh33445cvyvzpffg9g-lld-19.1.7"
+        "dev": "/nix/store/1n9hnnlysg7gm1s4qj57jz9x8jbsgbyr-lld-21.1.8-dev",
+        "lib": "/nix/store/z0z0hp2zs02m5yvnbm7fkygqhkfpvynf-lld-21.1.8-lib",
+        "out": "/nix/store/ngi05wj04dmlh8jlapjh4ndkrf27331i-lld-21.1.8"
       },
       "system": "aarch64-darwin",
       "group": "toplevel",
@@ -1730,29 +1734,29 @@
     {
       "attr_path": "lld",
       "broken": false,
-      "derivation": "/nix/store/xzzzh7jvqzz0wrzi34hj2gp0x88iy8n0-lld-19.1.7.drv",
+      "derivation": "/nix/store/6bkwrxq0j0vr3cgxdy78pdcysi9lk1jy-lld-21.1.8.drv",
       "description": "LLVM linker (unwrapped)",
       "install_id": "lld",
       "license": "[ NCSA, Apache-2.0, LLVM-exception ]",
-      "locked_url": "https://github.com/flox/nixpkgs?rev=c23193b943c6c689d70ee98ce3128239ed9e32d1",
-      "name": "lld-19.1.7",
+      "locked_url": "https://github.com/flox/nixpkgs?rev=aca4d95fce4914b3892661bcb80b8087293536c6",
+      "name": "lld-21.1.8",
       "pname": "lld",
-      "rev": "c23193b943c6c689d70ee98ce3128239ed9e32d1",
-      "rev_count": 861038,
-      "rev_date": "2025-09-13T06:43:22Z",
-      "scrape_date": "2025-09-15T02:30:10.308112Z",
+      "rev": "aca4d95fce4914b3892661bcb80b8087293536c6",
+      "rev_count": 958961,
+      "rev_date": "2026-03-06T04:56:59Z",
+      "scrape_date": "2026-03-08T05:23:53.965615Z",
       "stabilities": [
         "unstable"
       ],
       "unfree": false,
-      "version": "19.1.7",
+      "version": "21.1.8",
       "outputs_to_install": [
         "out"
       ],
       "outputs": {
-        "dev": "/nix/store/fgnxjqv0hknjsk1j64a7602qa547lci8-lld-19.1.7-dev",
-        "lib": "/nix/store/rmsmslkbx5fy4rma3jza6wa0cb4jbkm2-lld-19.1.7-lib",
-        "out": "/nix/store/7j49zwxa3f6knw619kxf62hacdvcswnc-lld-19.1.7"
+        "dev": "/nix/store/k9irnjry6pkmilw6kpy4f21dfmwn72xw-lld-21.1.8-dev",
+        "lib": "/nix/store/vqc31fckcs92bs86aqqxi5bzx5847vhn-lld-21.1.8-lib",
+        "out": "/nix/store/86qr1a83p50z4clic8c8pwn8lybrzc2x-lld-21.1.8"
       },
       "system": "aarch64-linux",
       "group": "toplevel",
@@ -1761,29 +1765,29 @@
     {
       "attr_path": "lld",
       "broken": false,
-      "derivation": "/nix/store/21dcmyp421w65ipp8amgwljp2wkyr3y1-lld-19.1.7.drv",
+      "derivation": "/nix/store/ql8mav681jap9jhssna9nr6ybci74154-lld-21.1.8.drv",
       "description": "LLVM linker (unwrapped)",
       "install_id": "lld",
       "license": "[ NCSA, Apache-2.0, LLVM-exception ]",
-      "locked_url": "https://github.com/flox/nixpkgs?rev=c23193b943c6c689d70ee98ce3128239ed9e32d1",
-      "name": "lld-19.1.7",
+      "locked_url": "https://github.com/flox/nixpkgs?rev=aca4d95fce4914b3892661bcb80b8087293536c6",
+      "name": "lld-21.1.8",
       "pname": "lld",
-      "rev": "c23193b943c6c689d70ee98ce3128239ed9e32d1",
-      "rev_count": 861038,
-      "rev_date": "2025-09-13T06:43:22Z",
-      "scrape_date": "2025-09-15T02:56:53.198289Z",
+      "rev": "aca4d95fce4914b3892661bcb80b8087293536c6",
+      "rev_count": 958961,
+      "rev_date": "2026-03-06T04:56:59Z",
+      "scrape_date": "2026-03-08T06:04:07.618245Z",
       "stabilities": [
         "unstable"
       ],
       "unfree": false,
-      "version": "19.1.7",
+      "version": "21.1.8",
       "outputs_to_install": [
         "out"
       ],
       "outputs": {
-        "dev": "/nix/store/1qikfk9xj52xha7y208f10srcw66lwr1-lld-19.1.7-dev",
-        "lib": "/nix/store/i6n1i7nx0da5nr4whivxpnrmla1wsv2i-lld-19.1.7-lib",
-        "out": "/nix/store/v1xv2l3m5rb8n9120nqkwr9dxcbhm06g-lld-19.1.7"
+        "dev": "/nix/store/pnv4pq0v30v0h7cx5y7f4pvzd41i5238-lld-21.1.8-dev",
+        "lib": "/nix/store/7h9gpk4s847k7gyxip3lzpk4r2i4gznb-lld-21.1.8-lib",
+        "out": "/nix/store/lmicy9ip82b5nxarp83nfr7hq61c7qy0-lld-21.1.8"
       },
       "system": "x86_64-darwin",
       "group": "toplevel",
@@ -1792,29 +1796,29 @@
     {
       "attr_path": "lld",
       "broken": false,
-      "derivation": "/nix/store/al1fxiaxqjwmxmp524d2x8b6af0dymw5-lld-19.1.7.drv",
+      "derivation": "/nix/store/yffk0bd721psm3hl0d6bkazxrjczrpb2-lld-21.1.8.drv",
       "description": "LLVM linker (unwrapped)",
       "install_id": "lld",
       "license": "[ NCSA, Apache-2.0, LLVM-exception ]",
-      "locked_url": "https://github.com/flox/nixpkgs?rev=c23193b943c6c689d70ee98ce3128239ed9e32d1",
-      "name": "lld-19.1.7",
+      "locked_url": "https://github.com/flox/nixpkgs?rev=aca4d95fce4914b3892661bcb80b8087293536c6",
+      "name": "lld-21.1.8",
       "pname": "lld",
-      "rev": "c23193b943c6c689d70ee98ce3128239ed9e32d1",
-      "rev_count": 861038,
-      "rev_date": "2025-09-13T06:43:22Z",
-      "scrape_date": "2025-09-15T03:27:28.715657Z",
+      "rev": "aca4d95fce4914b3892661bcb80b8087293536c6",
+      "rev_count": 958961,
+      "rev_date": "2026-03-06T04:56:59Z",
+      "scrape_date": "2026-03-08T06:47:11.344922Z",
       "stabilities": [
         "unstable"
       ],
       "unfree": false,
-      "version": "19.1.7",
+      "version": "21.1.8",
       "outputs_to_install": [
         "out"
       ],
       "outputs": {
-        "dev": "/nix/store/6bca5i74dy8qb44vp4dlq0z2fma2cdxr-lld-19.1.7-dev",
-        "lib": "/nix/store/8vrq2qcw8ic6hvlspc6rqccy35yklqcs-lld-19.1.7-lib",
-        "out": "/nix/store/34xsb4b01nlaifsp2fpjwvcnxjy9aljw-lld-19.1.7"
+        "dev": "/nix/store/r90r1wj900jqknrvbwhzdd91fi32929q-lld-21.1.8-dev",
+        "lib": "/nix/store/v94nchbcr0i0ih6zap3dkc3axh6chq6s-lld-21.1.8-lib",
+        "out": "/nix/store/8pkfxq43pva8va7izw27pjb3qzd00rgb-lld-21.1.8"
       },
       "system": "x86_64-linux",
       "group": "toplevel",
@@ -1823,27 +1827,27 @@
     {
       "attr_path": "markdownlint-cli",
       "broken": false,
-      "derivation": "/nix/store/mg9jq4q3g6xs92667qxw8yy25inzl334-markdownlint-cli-0.45.0.drv",
+      "derivation": "/nix/store/xmcf9x9b9q548zqq4if06nqw1bn07fjy-markdownlint-cli-0.48.0.drv",
       "description": "Command line interface for MarkdownLint",
       "install_id": "markdownlint-cli",
       "license": "MIT",
-      "locked_url": "https://github.com/flox/nixpkgs?rev=c23193b943c6c689d70ee98ce3128239ed9e32d1",
-      "name": "markdownlint-cli-0.45.0",
+      "locked_url": "https://github.com/flox/nixpkgs?rev=aca4d95fce4914b3892661bcb80b8087293536c6",
+      "name": "markdownlint-cli-0.48.0",
       "pname": "markdownlint-cli",
-      "rev": "c23193b943c6c689d70ee98ce3128239ed9e32d1",
-      "rev_count": 861038,
-      "rev_date": "2025-09-13T06:43:22Z",
-      "scrape_date": "2025-09-15T02:01:02.774266Z",
+      "rev": "aca4d95fce4914b3892661bcb80b8087293536c6",
+      "rev_count": 958961,
+      "rev_date": "2026-03-06T04:56:59Z",
+      "scrape_date": "2026-03-08T04:47:04.368814Z",
       "stabilities": [
         "unstable"
       ],
       "unfree": false,
-      "version": "0.45.0",
+      "version": "0.48.0",
       "outputs_to_install": [
         "out"
       ],
       "outputs": {
-        "out": "/nix/store/4ig0wm21js63xc4gavr13cd2i6k0mz4q-markdownlint-cli-0.45.0"
+        "out": "/nix/store/19q7y4nbfgkkrr6s8pwgnz6377xw9c7j-markdownlint-cli-0.48.0"
       },
       "system": "aarch64-darwin",
       "group": "toplevel",
@@ -1852,27 +1856,27 @@
     {
       "attr_path": "markdownlint-cli",
       "broken": false,
-      "derivation": "/nix/store/wvh81vh3b8a5jks1p5ln64i6xybacjwm-markdownlint-cli-0.45.0.drv",
+      "derivation": "/nix/store/6fv9m7j0lxn0cajsadr7ay66ikamm156-markdownlint-cli-0.48.0.drv",
       "description": "Command line interface for MarkdownLint",
       "install_id": "markdownlint-cli",
       "license": "MIT",
-      "locked_url": "https://github.com/flox/nixpkgs?rev=c23193b943c6c689d70ee98ce3128239ed9e32d1",
-      "name": "markdownlint-cli-0.45.0",
+      "locked_url": "https://github.com/flox/nixpkgs?rev=aca4d95fce4914b3892661bcb80b8087293536c6",
+      "name": "markdownlint-cli-0.48.0",
       "pname": "markdownlint-cli",
-      "rev": "c23193b943c6c689d70ee98ce3128239ed9e32d1",
-      "rev_count": 861038,
-      "rev_date": "2025-09-13T06:43:22Z",
-      "scrape_date": "2025-09-15T02:30:13.823128Z",
+      "rev": "aca4d95fce4914b3892661bcb80b8087293536c6",
+      "rev_count": 958961,
+      "rev_date": "2026-03-06T04:56:59Z",
+      "scrape_date": "2026-03-08T05:23:57.552086Z",
       "stabilities": [
         "unstable"
       ],
       "unfree": false,
-      "version": "0.45.0",
+      "version": "0.48.0",
       "outputs_to_install": [
         "out"
       ],
       "outputs": {
-        "out": "/nix/store/vj2drl5lxx7lc2mscd3qcsw5c5g9vxl6-markdownlint-cli-0.45.0"
+        "out": "/nix/store/xn1mbr0hycbvgmjpvc19cpzw04w4c0i5-markdownlint-cli-0.48.0"
       },
       "system": "aarch64-linux",
       "group": "toplevel",
@@ -1881,27 +1885,27 @@
     {
       "attr_path": "markdownlint-cli",
       "broken": false,
-      "derivation": "/nix/store/d3ndsd4xzpfrysh9ggbnhkyxwapkh0ds-markdownlint-cli-0.45.0.drv",
+      "derivation": "/nix/store/vb9bnp58h0lglrsqlb05skgy1sik73zd-markdownlint-cli-0.48.0.drv",
       "description": "Command line interface for MarkdownLint",
       "install_id": "markdownlint-cli",
       "license": "MIT",
-      "locked_url": "https://github.com/flox/nixpkgs?rev=c23193b943c6c689d70ee98ce3128239ed9e32d1",
-      "name": "markdownlint-cli-0.45.0",
+      "locked_url": "https://github.com/flox/nixpkgs?rev=aca4d95fce4914b3892661bcb80b8087293536c6",
+      "name": "markdownlint-cli-0.48.0",
       "pname": "markdownlint-cli",
-      "rev": "c23193b943c6c689d70ee98ce3128239ed9e32d1",
-      "rev_count": 861038,
-      "rev_date": "2025-09-13T06:43:22Z",
-      "scrape_date": "2025-09-15T02:56:55.459789Z",
+      "rev": "aca4d95fce4914b3892661bcb80b8087293536c6",
+      "rev_count": 958961,
+      "rev_date": "2026-03-06T04:56:59Z",
+      "scrape_date": "2026-03-08T06:04:09.907986Z",
       "stabilities": [
         "unstable"
       ],
       "unfree": false,
-      "version": "0.45.0",
+      "version": "0.48.0",
       "outputs_to_install": [
         "out"
       ],
       "outputs": {
-        "out": "/nix/store/38j4cw3xh1z63a1jjfbam5bl8cp8zv7v-markdownlint-cli-0.45.0"
+        "out": "/nix/store/711nrz3ssxflv3qschhkhj21xk1zq0df-markdownlint-cli-0.48.0"
       },
       "system": "x86_64-darwin",
       "group": "toplevel",
@@ -1910,27 +1914,27 @@
     {
       "attr_path": "markdownlint-cli",
       "broken": false,
-      "derivation": "/nix/store/y7jlnzya9k4sqy1rkbr6xr9qcmqw84ss-markdownlint-cli-0.45.0.drv",
+      "derivation": "/nix/store/qhcax0z1w6fdljxyg5fqirbr996a7izp-markdownlint-cli-0.48.0.drv",
       "description": "Command line interface for MarkdownLint",
       "install_id": "markdownlint-cli",
       "license": "MIT",
-      "locked_url": "https://github.com/flox/nixpkgs?rev=c23193b943c6c689d70ee98ce3128239ed9e32d1",
-      "name": "markdownlint-cli-0.45.0",
+      "locked_url": "https://github.com/flox/nixpkgs?rev=aca4d95fce4914b3892661bcb80b8087293536c6",
+      "name": "markdownlint-cli-0.48.0",
       "pname": "markdownlint-cli",
-      "rev": "c23193b943c6c689d70ee98ce3128239ed9e32d1",
-      "rev_count": 861038,
-      "rev_date": "2025-09-13T06:43:22Z",
-      "scrape_date": "2025-09-15T03:27:32.348591Z",
+      "rev": "aca4d95fce4914b3892661bcb80b8087293536c6",
+      "rev_count": 958961,
+      "rev_date": "2026-03-06T04:56:59Z",
+      "scrape_date": "2026-03-08T06:47:15.047450Z",
       "stabilities": [
         "unstable"
       ],
       "unfree": false,
-      "version": "0.45.0",
+      "version": "0.48.0",
       "outputs_to_install": [
         "out"
       ],
       "outputs": {
-        "out": "/nix/store/7909ka0w0s4057p0c1ndccd4ggx29plw-markdownlint-cli-0.45.0"
+        "out": "/nix/store/ddazwp5mnsfp3vd7m6zm6gxhix34s71f-markdownlint-cli-0.48.0"
       },
       "system": "x86_64-linux",
       "group": "toplevel",
@@ -1939,30 +1943,30 @@
     {
       "attr_path": "parallel",
       "broken": false,
-      "derivation": "/nix/store/3kin9rddgaia6fxi2rbvp11syd19lpcl-parallel-20250822.drv",
+      "derivation": "/nix/store/gxiwf98mn5jz1fq4b24g7mp4kpq2b2x5-parallel-20260122.drv",
       "description": "Shell tool for executing jobs in parallel",
       "install_id": "parallel",
       "license": "GPL-3.0-or-later",
-      "locked_url": "https://github.com/flox/nixpkgs?rev=c23193b943c6c689d70ee98ce3128239ed9e32d1",
-      "name": "parallel-20250822",
+      "locked_url": "https://github.com/flox/nixpkgs?rev=aca4d95fce4914b3892661bcb80b8087293536c6",
+      "name": "parallel-20260122",
       "pname": "parallel",
-      "rev": "c23193b943c6c689d70ee98ce3128239ed9e32d1",
-      "rev_count": 861038,
-      "rev_date": "2025-09-13T06:43:22Z",
-      "scrape_date": "2025-09-15T02:01:08.974455Z",
+      "rev": "aca4d95fce4914b3892661bcb80b8087293536c6",
+      "rev_count": 958961,
+      "rev_date": "2026-03-06T04:56:59Z",
+      "scrape_date": "2026-03-08T04:47:12.625887Z",
       "stabilities": [
         "unstable"
       ],
       "unfree": false,
-      "version": "20250822",
+      "version": "20260122",
       "outputs_to_install": [
         "man",
         "out"
       ],
       "outputs": {
-        "doc": "/nix/store/cskgf2xabwyg475rplk914ds6kk6pifd-parallel-20250822-doc",
-        "man": "/nix/store/lpi8n9qif95q7l3xd7sd6zmp002vab1z-parallel-20250822-man",
-        "out": "/nix/store/j987h37rjld910jlsi0xjyfpyqsckq3x-parallel-20250822"
+        "doc": "/nix/store/nr5h30pqyayhp8jvdy7q716hhbzi4vby-parallel-20260122-doc",
+        "man": "/nix/store/qbv779jb0b3mmrc741hsrqs8jyn563r8-parallel-20260122-man",
+        "out": "/nix/store/r5nxk4m4xqgazpysjk98mk96k2symkas-parallel-20260122"
       },
       "system": "aarch64-darwin",
       "group": "toplevel",
@@ -1971,30 +1975,30 @@
     {
       "attr_path": "parallel",
       "broken": false,
-      "derivation": "/nix/store/7f2gfps8pak641ghmgpfz8w9rs10i3lb-parallel-20250822.drv",
+      "derivation": "/nix/store/hg1hq4fvhsgk9gpmyywm2cjwlbdc0rfn-parallel-20260122.drv",
       "description": "Shell tool for executing jobs in parallel",
       "install_id": "parallel",
       "license": "GPL-3.0-or-later",
-      "locked_url": "https://github.com/flox/nixpkgs?rev=c23193b943c6c689d70ee98ce3128239ed9e32d1",
-      "name": "parallel-20250822",
+      "locked_url": "https://github.com/flox/nixpkgs?rev=aca4d95fce4914b3892661bcb80b8087293536c6",
+      "name": "parallel-20260122",
       "pname": "parallel",
-      "rev": "c23193b943c6c689d70ee98ce3128239ed9e32d1",
-      "rev_count": 861038,
-      "rev_date": "2025-09-13T06:43:22Z",
-      "scrape_date": "2025-09-15T02:30:23.417928Z",
+      "rev": "aca4d95fce4914b3892661bcb80b8087293536c6",
+      "rev_count": 958961,
+      "rev_date": "2026-03-06T04:56:59Z",
+      "scrape_date": "2026-03-08T05:24:10.627014Z",
       "stabilities": [
         "unstable"
       ],
       "unfree": false,
-      "version": "20250822",
+      "version": "20260122",
       "outputs_to_install": [
         "man",
         "out"
       ],
       "outputs": {
-        "doc": "/nix/store/3fkinyfs9m3mk6q65z0h1brc2hf4wvn7-parallel-20250822-doc",
-        "man": "/nix/store/4sq09imxd16yicy323dxavnwflxizapz-parallel-20250822-man",
-        "out": "/nix/store/bibhgmszfw8ivfqlxxdlkl9zisvk1gaf-parallel-20250822"
+        "doc": "/nix/store/agglpdjh96h5anz0yq8lfphs16s9rim3-parallel-20260122-doc",
+        "man": "/nix/store/yb5r65bg0q6282z55mxgpgmzsqp20rgb-parallel-20260122-man",
+        "out": "/nix/store/35736k56qbir2si5a1nvs3zspa5sq4ar-parallel-20260122"
       },
       "system": "aarch64-linux",
       "group": "toplevel",
@@ -2003,30 +2007,30 @@
     {
       "attr_path": "parallel",
       "broken": false,
-      "derivation": "/nix/store/gawlnw7rq39mmgnwlhvnnd6m4pdbm4vy-parallel-20250822.drv",
+      "derivation": "/nix/store/7vvfhbb61gnxydv6yihv9hy5lh27lp2n-parallel-20260122.drv",
       "description": "Shell tool for executing jobs in parallel",
       "install_id": "parallel",
       "license": "GPL-3.0-or-later",
-      "locked_url": "https://github.com/flox/nixpkgs?rev=c23193b943c6c689d70ee98ce3128239ed9e32d1",
-      "name": "parallel-20250822",
+      "locked_url": "https://github.com/flox/nixpkgs?rev=aca4d95fce4914b3892661bcb80b8087293536c6",
+      "name": "parallel-20260122",
       "pname": "parallel",
-      "rev": "c23193b943c6c689d70ee98ce3128239ed9e32d1",
-      "rev_count": 861038,
-      "rev_date": "2025-09-13T06:43:22Z",
-      "scrape_date": "2025-09-15T02:57:01.497928Z",
+      "rev": "aca4d95fce4914b3892661bcb80b8087293536c6",
+      "rev_count": 958961,
+      "rev_date": "2026-03-06T04:56:59Z",
+      "scrape_date": "2026-03-08T06:04:17.996241Z",
       "stabilities": [
         "unstable"
       ],
       "unfree": false,
-      "version": "20250822",
+      "version": "20260122",
       "outputs_to_install": [
         "man",
         "out"
       ],
       "outputs": {
-        "doc": "/nix/store/7kxwj6jpx4c2fcbffzbarlkd6vy6g3jv-parallel-20250822-doc",
-        "man": "/nix/store/qh6cj75l8z5h31yv5qrg4vv6rd7iawk7-parallel-20250822-man",
-        "out": "/nix/store/d5h8mvwn6wr51a26jzzr8018z5hbbcq2-parallel-20250822"
+        "doc": "/nix/store/kj1jb2hrs9hka71c8cabzp3zndd73dr7-parallel-20260122-doc",
+        "man": "/nix/store/fnpbsckh9ra2d674h1635wrncwck0ir1-parallel-20260122-man",
+        "out": "/nix/store/kj8v5mlvzwsvjppwfaybvwzidiwsqcg5-parallel-20260122"
       },
       "system": "x86_64-darwin",
       "group": "toplevel",
@@ -2035,30 +2039,30 @@
     {
       "attr_path": "parallel",
       "broken": false,
-      "derivation": "/nix/store/qmz7q1nphcv9g6p0phd5vriz233jc7lw-parallel-20250822.drv",
+      "derivation": "/nix/store/x2h4ri8vrmdsqns9klx7rvp03lpkhh0f-parallel-20260122.drv",
       "description": "Shell tool for executing jobs in parallel",
       "install_id": "parallel",
       "license": "GPL-3.0-or-later",
-      "locked_url": "https://github.com/flox/nixpkgs?rev=c23193b943c6c689d70ee98ce3128239ed9e32d1",
-      "name": "parallel-20250822",
+      "locked_url": "https://github.com/flox/nixpkgs?rev=aca4d95fce4914b3892661bcb80b8087293536c6",
+      "name": "parallel-20260122",
       "pname": "parallel",
-      "rev": "c23193b943c6c689d70ee98ce3128239ed9e32d1",
-      "rev_count": 861038,
-      "rev_date": "2025-09-13T06:43:22Z",
-      "scrape_date": "2025-09-15T03:27:42.423947Z",
+      "rev": "aca4d95fce4914b3892661bcb80b8087293536c6",
+      "rev_count": 958961,
+      "rev_date": "2026-03-06T04:56:59Z",
+      "scrape_date": "2026-03-08T06:47:28.536442Z",
       "stabilities": [
         "unstable"
       ],
       "unfree": false,
-      "version": "20250822",
+      "version": "20260122",
       "outputs_to_install": [
         "man",
         "out"
       ],
       "outputs": {
-        "doc": "/nix/store/nn1jgwmm052wqkhvvnny9mjj2wqcps5k-parallel-20250822-doc",
-        "man": "/nix/store/5l907gp7y97cy4brwhsk8gwzc632nxd2-parallel-20250822-man",
-        "out": "/nix/store/3yhw3cmzaz9d5bmwwqnxkr969rrjwxxg-parallel-20250822"
+        "doc": "/nix/store/bqai14k0f9v5l6nc3m7aqhqp0q1lczkv-parallel-20260122-doc",
+        "man": "/nix/store/asigykjz744x4rnsryy12555mx7kcmym-parallel-20260122-man",
+        "out": "/nix/store/ddi33l75b1xxlymvipkabqhi7hjava6k-parallel-20260122"
       },
       "system": "x86_64-linux",
       "group": "toplevel",
@@ -2067,17 +2071,17 @@
     {
       "attr_path": "prettier",
       "broken": false,
-      "derivation": "/nix/store/15483wc7579kgz9zhhmfg6h6jj0dc1vb-prettier-3.6.2.drv",
+      "derivation": "/nix/store/bmqcqc0kv6dr8yy0amlh38c5a9iz197k-prettier-3.6.2.drv",
       "description": "Code formatter",
       "install_id": "prettier",
       "license": "MIT",
-      "locked_url": "https://github.com/flox/nixpkgs?rev=c23193b943c6c689d70ee98ce3128239ed9e32d1",
+      "locked_url": "https://github.com/flox/nixpkgs?rev=aca4d95fce4914b3892661bcb80b8087293536c6",
       "name": "prettier-3.6.2",
       "pname": "prettier",
-      "rev": "c23193b943c6c689d70ee98ce3128239ed9e32d1",
-      "rev_count": 861038,
-      "rev_date": "2025-09-13T06:43:22Z",
-      "scrape_date": "2025-09-15T02:01:21.134629Z",
+      "rev": "aca4d95fce4914b3892661bcb80b8087293536c6",
+      "rev_count": 958961,
+      "rev_date": "2026-03-06T04:56:59Z",
+      "scrape_date": "2026-03-08T04:47:22.003242Z",
       "stabilities": [
         "unstable"
       ],
@@ -2087,7 +2091,7 @@
         "out"
       ],
       "outputs": {
-        "out": "/nix/store/r9ia4mcdp6p3sxkcxdjbkiw6w8mk3sjn-prettier-3.6.2"
+        "out": "/nix/store/727v1xvix6h5z349k6yslpa1nk1hxgds-prettier-3.6.2"
       },
       "system": "aarch64-darwin",
       "group": "toplevel",
@@ -2096,17 +2100,17 @@
     {
       "attr_path": "prettier",
       "broken": false,
-      "derivation": "/nix/store/sga30lmggphrwz1yv4398pmqg5g1nsqq-prettier-3.6.2.drv",
+      "derivation": "/nix/store/4ww4mj3gp9x1gk6zmx5yrax5xg80knxy-prettier-3.6.2.drv",
       "description": "Code formatter",
       "install_id": "prettier",
       "license": "MIT",
-      "locked_url": "https://github.com/flox/nixpkgs?rev=c23193b943c6c689d70ee98ce3128239ed9e32d1",
+      "locked_url": "https://github.com/flox/nixpkgs?rev=aca4d95fce4914b3892661bcb80b8087293536c6",
       "name": "prettier-3.6.2",
       "pname": "prettier",
-      "rev": "c23193b943c6c689d70ee98ce3128239ed9e32d1",
-      "rev_count": 861038,
-      "rev_date": "2025-09-13T06:43:22Z",
-      "scrape_date": "2025-09-15T02:30:39.455981Z",
+      "rev": "aca4d95fce4914b3892661bcb80b8087293536c6",
+      "rev_count": 958961,
+      "rev_date": "2026-03-06T04:56:59Z",
+      "scrape_date": "2026-03-08T05:24:23.443628Z",
       "stabilities": [
         "unstable"
       ],
@@ -2116,7 +2120,7 @@
         "out"
       ],
       "outputs": {
-        "out": "/nix/store/rrfwfq4wb2ga8y7aj6cq1z03ridvmv7l-prettier-3.6.2"
+        "out": "/nix/store/srrwdkd9307kqd6g3qzcn96affxf59vc-prettier-3.6.2"
       },
       "system": "aarch64-linux",
       "group": "toplevel",
@@ -2125,17 +2129,17 @@
     {
       "attr_path": "prettier",
       "broken": false,
-      "derivation": "/nix/store/8xdf71bfsyx1fcbj8aywic7yh2z69s7m-prettier-3.6.2.drv",
+      "derivation": "/nix/store/givyvqmqki8l8zqh1ijcffrqajv6rqwk-prettier-3.6.2.drv",
       "description": "Code formatter",
       "install_id": "prettier",
       "license": "MIT",
-      "locked_url": "https://github.com/flox/nixpkgs?rev=c23193b943c6c689d70ee98ce3128239ed9e32d1",
+      "locked_url": "https://github.com/flox/nixpkgs?rev=aca4d95fce4914b3892661bcb80b8087293536c6",
       "name": "prettier-3.6.2",
       "pname": "prettier",
-      "rev": "c23193b943c6c689d70ee98ce3128239ed9e32d1",
-      "rev_count": 861038,
-      "rev_date": "2025-09-13T06:43:22Z",
-      "scrape_date": "2025-09-15T02:57:13.738491Z",
+      "rev": "aca4d95fce4914b3892661bcb80b8087293536c6",
+      "rev_count": 958961,
+      "rev_date": "2026-03-06T04:56:59Z",
+      "scrape_date": "2026-03-08T06:04:27.201123Z",
       "stabilities": [
         "unstable"
       ],
@@ -2145,7 +2149,7 @@
         "out"
       ],
       "outputs": {
-        "out": "/nix/store/sqrvknf9fhb193y6vklgc18rh8nwl42j-prettier-3.6.2"
+        "out": "/nix/store/p7fkyhr9hgn1y23fg1s9r64pbrjg3nlm-prettier-3.6.2"
       },
       "system": "x86_64-darwin",
       "group": "toplevel",
@@ -2154,17 +2158,17 @@
     {
       "attr_path": "prettier",
       "broken": false,
-      "derivation": "/nix/store/zmjk2ihfvyj3ps1d72rd7w6y70dplyl4-prettier-3.6.2.drv",
+      "derivation": "/nix/store/m05c9k55q4v2d2361ya4wdlb3nsyvia1-prettier-3.6.2.drv",
       "description": "Code formatter",
       "install_id": "prettier",
       "license": "MIT",
-      "locked_url": "https://github.com/flox/nixpkgs?rev=c23193b943c6c689d70ee98ce3128239ed9e32d1",
+      "locked_url": "https://github.com/flox/nixpkgs?rev=aca4d95fce4914b3892661bcb80b8087293536c6",
       "name": "prettier-3.6.2",
       "pname": "prettier",
-      "rev": "c23193b943c6c689d70ee98ce3128239ed9e32d1",
-      "rev_count": 861038,
-      "rev_date": "2025-09-13T06:43:22Z",
-      "scrape_date": "2025-09-15T03:27:59.327151Z",
+      "rev": "aca4d95fce4914b3892661bcb80b8087293536c6",
+      "rev_count": 958961,
+      "rev_date": "2026-03-06T04:56:59Z",
+      "scrape_date": "2026-03-08T06:47:42.063443Z",
       "stabilities": [
         "unstable"
       ],
@@ -2174,7 +2178,7 @@
         "out"
       ],
       "outputs": {
-        "out": "/nix/store/zbn6kjr06qgfvbc9cl95mnxkabgph30b-prettier-3.6.2"
+        "out": "/nix/store/8skdr5xqspbgwfvhj9hq91jnk6ir13kg-prettier-3.6.2"
       },
       "system": "x86_64-linux",
       "group": "toplevel",
@@ -2183,17 +2187,17 @@
     {
       "attr_path": "taplo",
       "broken": false,
-      "derivation": "/nix/store/2yzg5s5n7cf3inj5pygn1v2pxyy69l0v-taplo-0.10.0.drv",
+      "derivation": "/nix/store/fhnmqmk9cwwc0gzvl3cdh6dlnydsgizc-taplo-0.10.0.drv",
       "description": "TOML toolkit written in Rust",
       "install_id": "taplo",
       "license": "MIT",
-      "locked_url": "https://github.com/flox/nixpkgs?rev=c23193b943c6c689d70ee98ce3128239ed9e32d1",
+      "locked_url": "https://github.com/flox/nixpkgs?rev=aca4d95fce4914b3892661bcb80b8087293536c6",
       "name": "taplo-0.10.0",
       "pname": "taplo",
-      "rev": "c23193b943c6c689d70ee98ce3128239ed9e32d1",
-      "rev_count": 861038,
-      "rev_date": "2025-09-13T06:43:22Z",
-      "scrape_date": "2025-09-15T02:02:30.123244Z",
+      "rev": "aca4d95fce4914b3892661bcb80b8087293536c6",
+      "rev_count": 958961,
+      "rev_date": "2026-03-06T04:56:59Z",
+      "scrape_date": "2026-03-08T04:48:30.823609Z",
       "stabilities": [
         "unstable"
       ],
@@ -2203,7 +2207,7 @@
         "out"
       ],
       "outputs": {
-        "out": "/nix/store/iv296lx84zjqcn80yx3b6g3dz3lpdxly-taplo-0.10.0"
+        "out": "/nix/store/bxmpz7vzhmnlhc7valxa5gqvppzmyv0d-taplo-0.10.0"
       },
       "system": "aarch64-darwin",
       "group": "toplevel",
@@ -2212,17 +2216,17 @@
     {
       "attr_path": "taplo",
       "broken": false,
-      "derivation": "/nix/store/5q52rbwjnx0gq9hrdmn002paqag3icgk-taplo-0.10.0.drv",
+      "derivation": "/nix/store/ki5jcd3hwr85ssvvlx23dmf16ckp7gwk-taplo-0.10.0.drv",
       "description": "TOML toolkit written in Rust",
       "install_id": "taplo",
       "license": "MIT",
-      "locked_url": "https://github.com/flox/nixpkgs?rev=c23193b943c6c689d70ee98ce3128239ed9e32d1",
+      "locked_url": "https://github.com/flox/nixpkgs?rev=aca4d95fce4914b3892661bcb80b8087293536c6",
       "name": "taplo-0.10.0",
       "pname": "taplo",
-      "rev": "c23193b943c6c689d70ee98ce3128239ed9e32d1",
-      "rev_count": 861038,
-      "rev_date": "2025-09-13T06:43:22Z",
-      "scrape_date": "2025-09-15T02:32:05.877794Z",
+      "rev": "aca4d95fce4914b3892661bcb80b8087293536c6",
+      "rev_count": 958961,
+      "rev_date": "2026-03-06T04:56:59Z",
+      "scrape_date": "2026-03-08T05:25:51.793916Z",
       "stabilities": [
         "unstable"
       ],
@@ -2232,7 +2236,7 @@
         "out"
       ],
       "outputs": {
-        "out": "/nix/store/ka4fa2swzfwnfnrb8zs0jjqj771imps7-taplo-0.10.0"
+        "out": "/nix/store/6nggarm1vbcjqc5fj67v715y058pi39k-taplo-0.10.0"
       },
       "system": "aarch64-linux",
       "group": "toplevel",
@@ -2241,17 +2245,17 @@
     {
       "attr_path": "taplo",
       "broken": false,
-      "derivation": "/nix/store/9vhrgnyd15j0qa9j08ikc16x2xdqkwwr-taplo-0.10.0.drv",
+      "derivation": "/nix/store/6b9rw17whl2f03dgzkcyslycdf7qa4cy-taplo-0.10.0.drv",
       "description": "TOML toolkit written in Rust",
       "install_id": "taplo",
       "license": "MIT",
-      "locked_url": "https://github.com/flox/nixpkgs?rev=c23193b943c6c689d70ee98ce3128239ed9e32d1",
+      "locked_url": "https://github.com/flox/nixpkgs?rev=aca4d95fce4914b3892661bcb80b8087293536c6",
       "name": "taplo-0.10.0",
       "pname": "taplo",
-      "rev": "c23193b943c6c689d70ee98ce3128239ed9e32d1",
-      "rev_count": 861038,
-      "rev_date": "2025-09-13T06:43:22Z",
-      "scrape_date": "2025-09-15T02:58:22.264772Z",
+      "rev": "aca4d95fce4914b3892661bcb80b8087293536c6",
+      "rev_count": 958961,
+      "rev_date": "2026-03-06T04:56:59Z",
+      "scrape_date": "2026-03-08T06:05:33.961910Z",
       "stabilities": [
         "unstable"
       ],
@@ -2261,7 +2265,7 @@
         "out"
       ],
       "outputs": {
-        "out": "/nix/store/njv5kychd9a6qwvzmwxxbyq2paxnkdj6-taplo-0.10.0"
+        "out": "/nix/store/bqzrr5avwnc8zzi6c4n1pdvwadkq9bip-taplo-0.10.0"
       },
       "system": "x86_64-darwin",
       "group": "toplevel",
@@ -2270,17 +2274,17 @@
     {
       "attr_path": "taplo",
       "broken": false,
-      "derivation": "/nix/store/v3yxa1bda02r1dpfr3saz2jw847fn43y-taplo-0.10.0.drv",
+      "derivation": "/nix/store/j8gw2yswppx59wwxlcpx4c6inmip39np-taplo-0.10.0.drv",
       "description": "TOML toolkit written in Rust",
       "install_id": "taplo",
       "license": "MIT",
-      "locked_url": "https://github.com/flox/nixpkgs?rev=c23193b943c6c689d70ee98ce3128239ed9e32d1",
+      "locked_url": "https://github.com/flox/nixpkgs?rev=aca4d95fce4914b3892661bcb80b8087293536c6",
       "name": "taplo-0.10.0",
       "pname": "taplo",
-      "rev": "c23193b943c6c689d70ee98ce3128239ed9e32d1",
-      "rev_count": 861038,
-      "rev_date": "2025-09-13T06:43:22Z",
-      "scrape_date": "2025-09-15T03:29:30.144764Z",
+      "rev": "aca4d95fce4914b3892661bcb80b8087293536c6",
+      "rev_count": 958961,
+      "rev_date": "2026-03-06T04:56:59Z",
+      "scrape_date": "2026-03-08T06:49:17.338658Z",
       "stabilities": [
         "unstable"
       ],
@@ -2290,7 +2294,7 @@
         "out"
       ],
       "outputs": {
-        "out": "/nix/store/0ylhpa0vki4d9c7n68nn1nwgfvq1hb6l-taplo-0.10.0"
+        "out": "/nix/store/xnyh9bi9wap6m3fq94q6sbav2qhh8f0d-taplo-0.10.0"
       },
       "system": "x86_64-linux",
       "group": "toplevel",
@@ -2299,17 +2303,17 @@
     {
       "attr_path": "trunk",
       "broken": false,
-      "derivation": "/nix/store/5kvr0h0cqlbzgj7mprvijv3c5gwcd22b-trunk-0.21.14.drv",
+      "derivation": "/nix/store/njd3bgbi10xx562a3xvziiwj57cr4v6h-trunk-0.21.14.drv",
       "description": "Build, bundle & ship your Rust WASM application to the web",
       "install_id": "trunk",
       "license": "[ Apache-2.0 ]",
-      "locked_url": "https://github.com/flox/nixpkgs?rev=c23193b943c6c689d70ee98ce3128239ed9e32d1",
+      "locked_url": "https://github.com/flox/nixpkgs?rev=aca4d95fce4914b3892661bcb80b8087293536c6",
       "name": "trunk-0.21.14",
       "pname": "trunk",
-      "rev": "c23193b943c6c689d70ee98ce3128239ed9e32d1",
-      "rev_count": 861038,
-      "rev_date": "2025-09-13T06:43:22Z",
-      "scrape_date": "2025-09-15T02:02:49.578217Z",
+      "rev": "aca4d95fce4914b3892661bcb80b8087293536c6",
+      "rev_count": 958961,
+      "rev_date": "2026-03-06T04:56:59Z",
+      "scrape_date": "2026-03-08T04:48:52.054790Z",
       "stabilities": [
         "unstable"
       ],
@@ -2319,7 +2323,7 @@
         "out"
       ],
       "outputs": {
-        "out": "/nix/store/pmb9v1935g53g0cidxjlg3bribp77vvi-trunk-0.21.14"
+        "out": "/nix/store/61pcb5g5qsazfml4676nyd8s65mysjl9-trunk-0.21.14"
       },
       "system": "aarch64-darwin",
       "group": "toplevel",
@@ -2328,17 +2332,17 @@
     {
       "attr_path": "trunk",
       "broken": false,
-      "derivation": "/nix/store/l1ni27k209252np1vjd8jf4xmjlyzn8i-trunk-0.21.14.drv",
+      "derivation": "/nix/store/fr9i2jg9j964fkivnfi228bic9kbahws-trunk-0.21.14.drv",
       "description": "Build, bundle & ship your Rust WASM application to the web",
       "install_id": "trunk",
       "license": "[ Apache-2.0 ]",
-      "locked_url": "https://github.com/flox/nixpkgs?rev=c23193b943c6c689d70ee98ce3128239ed9e32d1",
+      "locked_url": "https://github.com/flox/nixpkgs?rev=aca4d95fce4914b3892661bcb80b8087293536c6",
       "name": "trunk-0.21.14",
       "pname": "trunk",
-      "rev": "c23193b943c6c689d70ee98ce3128239ed9e32d1",
-      "rev_count": 861038,
-      "rev_date": "2025-09-13T06:43:22Z",
-      "scrape_date": "2025-09-15T02:32:30.193526Z",
+      "rev": "aca4d95fce4914b3892661bcb80b8087293536c6",
+      "rev_count": 958961,
+      "rev_date": "2026-03-06T04:56:59Z",
+      "scrape_date": "2026-03-08T05:26:22.680832Z",
       "stabilities": [
         "unstable"
       ],
@@ -2348,7 +2352,7 @@
         "out"
       ],
       "outputs": {
-        "out": "/nix/store/sldzwzq1bxzfb9xqhghc4y0r7xfvm8y0-trunk-0.21.14"
+        "out": "/nix/store/sxvpkdalsqbkm4csvjxbl624yw3d8gfm-trunk-0.21.14"
       },
       "system": "aarch64-linux",
       "group": "toplevel",
@@ -2357,17 +2361,17 @@
     {
       "attr_path": "trunk",
       "broken": false,
-      "derivation": "/nix/store/7vgh6988zl4zcgd76babikkaxkqwvyal-trunk-0.21.14.drv",
+      "derivation": "/nix/store/hmq2gj1jz85a624mpq02rhlj4cjpfdy4-trunk-0.21.14.drv",
       "description": "Build, bundle & ship your Rust WASM application to the web",
       "install_id": "trunk",
       "license": "[ Apache-2.0 ]",
-      "locked_url": "https://github.com/flox/nixpkgs?rev=c23193b943c6c689d70ee98ce3128239ed9e32d1",
+      "locked_url": "https://github.com/flox/nixpkgs?rev=aca4d95fce4914b3892661bcb80b8087293536c6",
       "name": "trunk-0.21.14",
       "pname": "trunk",
-      "rev": "c23193b943c6c689d70ee98ce3128239ed9e32d1",
-      "rev_count": 861038,
-      "rev_date": "2025-09-13T06:43:22Z",
-      "scrape_date": "2025-09-15T02:58:41.671890Z",
+      "rev": "aca4d95fce4914b3892661bcb80b8087293536c6",
+      "rev_count": 958961,
+      "rev_date": "2026-03-06T04:56:59Z",
+      "scrape_date": "2026-03-08T06:05:54.530273Z",
       "stabilities": [
         "unstable"
       ],
@@ -2377,7 +2381,7 @@
         "out"
       ],
       "outputs": {
-        "out": "/nix/store/xflvkahhxd0l8k9jix0aicidac00nfx7-trunk-0.21.14"
+        "out": "/nix/store/ncnklrhfl22ys7n66hr1dabw8jqf8c8r-trunk-0.21.14"
       },
       "system": "x86_64-darwin",
       "group": "toplevel",
@@ -2386,17 +2390,17 @@
     {
       "attr_path": "trunk",
       "broken": false,
-      "derivation": "/nix/store/r69jvdprgbmayf995vhy4syial9hy48d-trunk-0.21.14.drv",
+      "derivation": "/nix/store/llvi83wvzmcvb6pgyv45r0arzr8v3xhw-trunk-0.21.14.drv",
       "description": "Build, bundle & ship your Rust WASM application to the web",
       "install_id": "trunk",
       "license": "[ Apache-2.0 ]",
-      "locked_url": "https://github.com/flox/nixpkgs?rev=c23193b943c6c689d70ee98ce3128239ed9e32d1",
+      "locked_url": "https://github.com/flox/nixpkgs?rev=aca4d95fce4914b3892661bcb80b8087293536c6",
       "name": "trunk-0.21.14",
       "pname": "trunk",
-      "rev": "c23193b943c6c689d70ee98ce3128239ed9e32d1",
-      "rev_count": 861038,
-      "rev_date": "2025-09-13T06:43:22Z",
-      "scrape_date": "2025-09-15T03:29:54.933892Z",
+      "rev": "aca4d95fce4914b3892661bcb80b8087293536c6",
+      "rev_count": 958961,
+      "rev_date": "2026-03-06T04:56:59Z",
+      "scrape_date": "2026-03-08T06:49:47.886638Z",
       "stabilities": [
         "unstable"
       ],
@@ -2406,7 +2410,7 @@
         "out"
       ],
       "outputs": {
-        "out": "/nix/store/a1ch6bc1nf0rshglnv1vxzcbb61lni0n-trunk-0.21.14"
+        "out": "/nix/store/fmww9356avy129m75swcpmmk4360xxhi-trunk-0.21.14"
       },
       "system": "x86_64-linux",
       "group": "toplevel",
@@ -2415,17 +2419,17 @@
     {
       "attr_path": "wasm-pack",
       "broken": false,
-      "derivation": "/nix/store/mlfc1yga8178bv7sqj9w95a1yspk6pfk-wasm-pack-0.13.1.drv",
+      "derivation": "/nix/store/sbzc7n7f48b5c9zi5q090af0slzi31yv-wasm-pack-0.13.1.drv",
       "description": "Utility that builds rust-generated WebAssembly package",
       "install_id": "wasm-pack",
       "license": "[ Apache-2.0, MIT ]",
-      "locked_url": "https://github.com/flox/nixpkgs?rev=c23193b943c6c689d70ee98ce3128239ed9e32d1",
+      "locked_url": "https://github.com/flox/nixpkgs?rev=aca4d95fce4914b3892661bcb80b8087293536c6",
       "name": "wasm-pack-0.13.1",
       "pname": "wasm-pack",
-      "rev": "c23193b943c6c689d70ee98ce3128239ed9e32d1",
-      "rev_count": 861038,
-      "rev_date": "2025-09-13T06:43:22Z",
-      "scrape_date": "2025-09-15T02:03:10.768516Z",
+      "rev": "aca4d95fce4914b3892661bcb80b8087293536c6",
+      "rev_count": 958961,
+      "rev_date": "2026-03-06T04:56:59Z",
+      "scrape_date": "2026-03-08T04:49:19.955310Z",
       "stabilities": [
         "unstable"
       ],
@@ -2435,7 +2439,7 @@
         "out"
       ],
       "outputs": {
-        "out": "/nix/store/42f5x8h50xgyr0m6k7kczlhfwnsg6cp9-wasm-pack-0.13.1"
+        "out": "/nix/store/4nc1m1ycrg28j8q5p5kpbgxkaigqhrzp-wasm-pack-0.13.1"
       },
       "system": "aarch64-darwin",
       "group": "toplevel",
@@ -2444,17 +2448,17 @@
     {
       "attr_path": "wasm-pack",
       "broken": false,
-      "derivation": "/nix/store/wzdax9a3ijn8fihz2sbhjb6cv55vs2jq-wasm-pack-0.13.1.drv",
+      "derivation": "/nix/store/81pzvkcm9qpzyijj9s9xy4ad3r7zc11k-wasm-pack-0.13.1.drv",
       "description": "Utility that builds rust-generated WebAssembly package",
       "install_id": "wasm-pack",
       "license": "[ Apache-2.0, MIT ]",
-      "locked_url": "https://github.com/flox/nixpkgs?rev=c23193b943c6c689d70ee98ce3128239ed9e32d1",
+      "locked_url": "https://github.com/flox/nixpkgs?rev=aca4d95fce4914b3892661bcb80b8087293536c6",
       "name": "wasm-pack-0.13.1",
       "pname": "wasm-pack",
-      "rev": "c23193b943c6c689d70ee98ce3128239ed9e32d1",
-      "rev_count": 861038,
-      "rev_date": "2025-09-13T06:43:22Z",
-      "scrape_date": "2025-09-15T02:32:55.342720Z",
+      "rev": "aca4d95fce4914b3892661bcb80b8087293536c6",
+      "rev_count": 958961,
+      "rev_date": "2026-03-06T04:56:59Z",
+      "scrape_date": "2026-03-08T05:26:56.849720Z",
       "stabilities": [
         "unstable"
       ],
@@ -2464,7 +2468,7 @@
         "out"
       ],
       "outputs": {
-        "out": "/nix/store/aal7jad1bqdpwfwvxm17ld8ww6kk1kfq-wasm-pack-0.13.1"
+        "out": "/nix/store/d837734jgi9rmx16dbrs0p9jqqxkpmag-wasm-pack-0.13.1"
       },
       "system": "aarch64-linux",
       "group": "toplevel",
@@ -2473,17 +2477,17 @@
     {
       "attr_path": "wasm-pack",
       "broken": false,
-      "derivation": "/nix/store/jljfsw6sbh9ch6r5g74adj2415vs154d-wasm-pack-0.13.1.drv",
+      "derivation": "/nix/store/rqr9hw37iqyapfdnaj7m36phwp2lhjdz-wasm-pack-0.13.1.drv",
       "description": "Utility that builds rust-generated WebAssembly package",
       "install_id": "wasm-pack",
       "license": "[ Apache-2.0, MIT ]",
-      "locked_url": "https://github.com/flox/nixpkgs?rev=c23193b943c6c689d70ee98ce3128239ed9e32d1",
+      "locked_url": "https://github.com/flox/nixpkgs?rev=aca4d95fce4914b3892661bcb80b8087293536c6",
       "name": "wasm-pack-0.13.1",
       "pname": "wasm-pack",
-      "rev": "c23193b943c6c689d70ee98ce3128239ed9e32d1",
-      "rev_count": 861038,
-      "rev_date": "2025-09-13T06:43:22Z",
-      "scrape_date": "2025-09-15T02:59:02.534355Z",
+      "rev": "aca4d95fce4914b3892661bcb80b8087293536c6",
+      "rev_count": 958961,
+      "rev_date": "2026-03-06T04:56:59Z",
+      "scrape_date": "2026-03-08T06:06:21.745474Z",
       "stabilities": [
         "unstable"
       ],
@@ -2493,7 +2497,7 @@
         "out"
       ],
       "outputs": {
-        "out": "/nix/store/w7hniks8wkxb0pmmdjl7d00g1qkf2ps9-wasm-pack-0.13.1"
+        "out": "/nix/store/sf8cbxk1ah5vww6r24hbs299ny0azqj6-wasm-pack-0.13.1"
       },
       "system": "x86_64-darwin",
       "group": "toplevel",
@@ -2502,17 +2506,17 @@
     {
       "attr_path": "wasm-pack",
       "broken": false,
-      "derivation": "/nix/store/ffv7wndfb201k13zi6ghy2zhj23wnapn-wasm-pack-0.13.1.drv",
+      "derivation": "/nix/store/87nvc4cc11amqwm3q4n19gbjga41jg0x-wasm-pack-0.13.1.drv",
       "description": "Utility that builds rust-generated WebAssembly package",
       "install_id": "wasm-pack",
       "license": "[ Apache-2.0, MIT ]",
-      "locked_url": "https://github.com/flox/nixpkgs?rev=c23193b943c6c689d70ee98ce3128239ed9e32d1",
+      "locked_url": "https://github.com/flox/nixpkgs?rev=aca4d95fce4914b3892661bcb80b8087293536c6",
       "name": "wasm-pack-0.13.1",
       "pname": "wasm-pack",
-      "rev": "c23193b943c6c689d70ee98ce3128239ed9e32d1",
-      "rev_count": 861038,
-      "rev_date": "2025-09-13T06:43:22Z",
-      "scrape_date": "2025-09-15T03:30:21.642984Z",
+      "rev": "aca4d95fce4914b3892661bcb80b8087293536c6",
+      "rev_count": 958961,
+      "rev_date": "2026-03-06T04:56:59Z",
+      "scrape_date": "2026-03-08T06:50:22.592668Z",
       "stabilities": [
         "unstable"
       ],
@@ -2522,7 +2526,7 @@
         "out"
       ],
       "outputs": {
-        "out": "/nix/store/nglgzdm77ird9jj3nnfyy4sdii5sh9w2-wasm-pack-0.13.1"
+        "out": "/nix/store/yr6d7vb9mgcv7gjhr5w197kyb28xvbhg-wasm-pack-0.13.1"
       },
       "system": "x86_64-linux",
       "group": "toplevel",
@@ -2531,17 +2535,17 @@
     {
       "attr_path": "yamllint",
       "broken": false,
-      "derivation": "/nix/store/51vi05vkk5yyh4qz9v10alfjpph45jn8-python3.13-yamllint-1.37.1.drv",
+      "derivation": "/nix/store/l8n6v244y0mgkdv9azaz6mix6j5pgl5c-python3.13-yamllint-1.37.1.drv",
       "description": "Linter for YAML files",
       "install_id": "yamllint",
       "license": "GPL-3.0-or-later",
-      "locked_url": "https://github.com/flox/nixpkgs?rev=c23193b943c6c689d70ee98ce3128239ed9e32d1",
+      "locked_url": "https://github.com/flox/nixpkgs?rev=aca4d95fce4914b3892661bcb80b8087293536c6",
       "name": "python3.13-yamllint-1.37.1",
       "pname": "yamllint",
-      "rev": "c23193b943c6c689d70ee98ce3128239ed9e32d1",
-      "rev_count": 861038,
-      "rev_date": "2025-09-13T06:43:22Z",
-      "scrape_date": "2025-09-15T02:03:13.634574Z",
+      "rev": "aca4d95fce4914b3892661bcb80b8087293536c6",
+      "rev_count": 958961,
+      "rev_date": "2026-03-06T04:56:59Z",
+      "scrape_date": "2026-03-08T04:49:22.354093Z",
       "stabilities": [
         "unstable"
       ],
@@ -2551,8 +2555,8 @@
         "out"
       ],
       "outputs": {
-        "dist": "/nix/store/nc9v27cadla3hzarrypl7xqv714aj851-python3.13-yamllint-1.37.1-dist",
-        "out": "/nix/store/1ajlhkwnvxnirqacd95ccvcp4n4a2l6d-python3.13-yamllint-1.37.1"
+        "dist": "/nix/store/55z9bkc64vm4b60rfn7y79ghklqkjsa5-python3.13-yamllint-1.37.1-dist",
+        "out": "/nix/store/3q7v9msz48z2vi736rymcjc1gi8c49iq-python3.13-yamllint-1.37.1"
       },
       "system": "aarch64-darwin",
       "group": "toplevel",
@@ -2561,17 +2565,17 @@
     {
       "attr_path": "yamllint",
       "broken": false,
-      "derivation": "/nix/store/62gqjm3pq4wcn11mk5h91png1fqi01ar-python3.13-yamllint-1.37.1.drv",
+      "derivation": "/nix/store/00c13kp5xf24534k4f04zjwsi61j6frw-python3.13-yamllint-1.37.1.drv",
       "description": "Linter for YAML files",
       "install_id": "yamllint",
       "license": "GPL-3.0-or-later",
-      "locked_url": "https://github.com/flox/nixpkgs?rev=c23193b943c6c689d70ee98ce3128239ed9e32d1",
+      "locked_url": "https://github.com/flox/nixpkgs?rev=aca4d95fce4914b3892661bcb80b8087293536c6",
       "name": "python3.13-yamllint-1.37.1",
       "pname": "yamllint",
-      "rev": "c23193b943c6c689d70ee98ce3128239ed9e32d1",
-      "rev_count": 861038,
-      "rev_date": "2025-09-13T06:43:22Z",
-      "scrape_date": "2025-09-15T02:33:00.420899Z",
+      "rev": "aca4d95fce4914b3892661bcb80b8087293536c6",
+      "rev_count": 958961,
+      "rev_date": "2026-03-06T04:56:59Z",
+      "scrape_date": "2026-03-08T05:27:02.038967Z",
       "stabilities": [
         "unstable"
       ],
@@ -2581,8 +2585,8 @@
         "out"
       ],
       "outputs": {
-        "dist": "/nix/store/llpps8kklgvx2m7xa8vnbfhcdrkirii7-python3.13-yamllint-1.37.1-dist",
-        "out": "/nix/store/wdn4zyww6gv95lhz0jvcfrf0an4vfbjf-python3.13-yamllint-1.37.1"
+        "dist": "/nix/store/fgs9isa3cyy2bg99vw92lyi3hmll7wnb-python3.13-yamllint-1.37.1-dist",
+        "out": "/nix/store/ianlcqlfq1zgswzrjyki2hnmc6n2k1hk-python3.13-yamllint-1.37.1"
       },
       "system": "aarch64-linux",
       "group": "toplevel",
@@ -2591,17 +2595,17 @@
     {
       "attr_path": "yamllint",
       "broken": false,
-      "derivation": "/nix/store/hfr7rzlqqkpsah6s863cbc9bg2pdqqk1-python3.13-yamllint-1.37.1.drv",
+      "derivation": "/nix/store/fh274blgs2nfw7h53k6601p66b0zm70h-python3.13-yamllint-1.37.1.drv",
       "description": "Linter for YAML files",
       "install_id": "yamllint",
       "license": "GPL-3.0-or-later",
-      "locked_url": "https://github.com/flox/nixpkgs?rev=c23193b943c6c689d70ee98ce3128239ed9e32d1",
+      "locked_url": "https://github.com/flox/nixpkgs?rev=aca4d95fce4914b3892661bcb80b8087293536c6",
       "name": "python3.13-yamllint-1.37.1",
       "pname": "yamllint",
-      "rev": "c23193b943c6c689d70ee98ce3128239ed9e32d1",
-      "rev_count": 861038,
-      "rev_date": "2025-09-13T06:43:22Z",
-      "scrape_date": "2025-09-15T02:59:05.426128Z",
+      "rev": "aca4d95fce4914b3892661bcb80b8087293536c6",
+      "rev_count": 958961,
+      "rev_date": "2026-03-06T04:56:59Z",
+      "scrape_date": "2026-03-08T06:06:24.166645Z",
       "stabilities": [
         "unstable"
       ],
@@ -2611,8 +2615,8 @@
         "out"
       ],
       "outputs": {
-        "dist": "/nix/store/hjh468yvb9nrw6jhizirvrjym8ngq35q-python3.13-yamllint-1.37.1-dist",
-        "out": "/nix/store/6yfzxvgkr2v043462sm2h6g2pjkm506n-python3.13-yamllint-1.37.1"
+        "dist": "/nix/store/9jmffbksg7dm2ja3gywcap9plspk4mpx-python3.13-yamllint-1.37.1-dist",
+        "out": "/nix/store/28i8a0xn0bwagyx1ql95f518qf6qy68d-python3.13-yamllint-1.37.1"
       },
       "system": "x86_64-darwin",
       "group": "toplevel",
@@ -2621,17 +2625,17 @@
     {
       "attr_path": "yamllint",
       "broken": false,
-      "derivation": "/nix/store/9x1wh1phq3qkjy8n0y866wlv1nii7ly5-python3.13-yamllint-1.37.1.drv",
+      "derivation": "/nix/store/maq6ldrg7nxfvy29j4z4vs7dfpgsj5nf-python3.13-yamllint-1.37.1.drv",
       "description": "Linter for YAML files",
       "install_id": "yamllint",
       "license": "GPL-3.0-or-later",
-      "locked_url": "https://github.com/flox/nixpkgs?rev=c23193b943c6c689d70ee98ce3128239ed9e32d1",
+      "locked_url": "https://github.com/flox/nixpkgs?rev=aca4d95fce4914b3892661bcb80b8087293536c6",
       "name": "python3.13-yamllint-1.37.1",
       "pname": "yamllint",
-      "rev": "c23193b943c6c689d70ee98ce3128239ed9e32d1",
-      "rev_count": 861038,
-      "rev_date": "2025-09-13T06:43:22Z",
-      "scrape_date": "2025-09-15T03:30:27.283049Z",
+      "rev": "aca4d95fce4914b3892661bcb80b8087293536c6",
+      "rev_count": 958961,
+      "rev_date": "2026-03-06T04:56:59Z",
+      "scrape_date": "2026-03-08T06:50:28.181511Z",
       "stabilities": [
         "unstable"
       ],
@@ -2641,8 +2645,8 @@
         "out"
       ],
       "outputs": {
-        "dist": "/nix/store/wpnf4f2x6qjkkk31s0505qiima771vxw-python3.13-yamllint-1.37.1-dist",
-        "out": "/nix/store/0v7zz7l98yw23xwk2j4fkccbj36dpjml-python3.13-yamllint-1.37.1"
+        "dist": "/nix/store/jk6is2i4c3qs0fp99qw6s5z8v3av20z2-python3.13-yamllint-1.37.1-dist",
+        "out": "/nix/store/a6k0l2naclakdmypd5frw9bgzyawnlmi-python3.13-yamllint-1.37.1"
       },
       "system": "x86_64-linux",
       "group": "toplevel",
@@ -2651,27 +2655,27 @@
     {
       "attr_path": "zizmor",
       "broken": false,
-      "derivation": "/nix/store/mlkvq3zr2aw0plgfyfn8jwd76lz6bjzh-zizmor-1.12.1.drv",
+      "derivation": "/nix/store/3c4bkjxb7w6lbxw1ghj2bn3vxrixs4za-zizmor-1.22.0.drv",
       "description": "Tool for finding security issues in GitHub Actions setups",
       "install_id": "zizmor",
       "license": "MIT",
-      "locked_url": "https://github.com/flox/nixpkgs?rev=c23193b943c6c689d70ee98ce3128239ed9e32d1",
-      "name": "zizmor-1.12.1",
+      "locked_url": "https://github.com/flox/nixpkgs?rev=aca4d95fce4914b3892661bcb80b8087293536c6",
+      "name": "zizmor-1.22.0",
       "pname": "zizmor",
-      "rev": "c23193b943c6c689d70ee98ce3128239ed9e32d1",
-      "rev_count": 861038,
-      "rev_date": "2025-09-13T06:43:22Z",
-      "scrape_date": "2025-09-15T02:03:14.613402Z",
+      "rev": "aca4d95fce4914b3892661bcb80b8087293536c6",
+      "rev_count": 958961,
+      "rev_date": "2026-03-06T04:56:59Z",
+      "scrape_date": "2026-03-08T04:49:23.345827Z",
       "stabilities": [
         "unstable"
       ],
       "unfree": false,
-      "version": "1.12.1",
+      "version": "1.22.0",
       "outputs_to_install": [
         "out"
       ],
       "outputs": {
-        "out": "/nix/store/zwz2yx0c7d8p78dfc4pjh8a5vmpihq9r-zizmor-1.12.1"
+        "out": "/nix/store/j3nc0mqid1z3l4q4546nakajy1hs2kkz-zizmor-1.22.0"
       },
       "system": "aarch64-darwin",
       "group": "toplevel",
@@ -2680,27 +2684,27 @@
     {
       "attr_path": "zizmor",
       "broken": false,
-      "derivation": "/nix/store/knl1cjzxh2vm5yiwwnm5gkc8xpiq9mhw-zizmor-1.12.1.drv",
+      "derivation": "/nix/store/zmzgg3k0zp6rwl7sd2y810nw39j34kh7-zizmor-1.22.0.drv",
       "description": "Tool for finding security issues in GitHub Actions setups",
       "install_id": "zizmor",
       "license": "MIT",
-      "locked_url": "https://github.com/flox/nixpkgs?rev=c23193b943c6c689d70ee98ce3128239ed9e32d1",
-      "name": "zizmor-1.12.1",
+      "locked_url": "https://github.com/flox/nixpkgs?rev=aca4d95fce4914b3892661bcb80b8087293536c6",
+      "name": "zizmor-1.22.0",
       "pname": "zizmor",
-      "rev": "c23193b943c6c689d70ee98ce3128239ed9e32d1",
-      "rev_count": 861038,
-      "rev_date": "2025-09-13T06:43:22Z",
-      "scrape_date": "2025-09-15T02:33:01.927865Z",
+      "rev": "aca4d95fce4914b3892661bcb80b8087293536c6",
+      "rev_count": 958961,
+      "rev_date": "2026-03-06T04:56:59Z",
+      "scrape_date": "2026-03-08T05:27:03.734525Z",
       "stabilities": [
         "unstable"
       ],
       "unfree": false,
-      "version": "1.12.1",
+      "version": "1.22.0",
       "outputs_to_install": [
         "out"
       ],
       "outputs": {
-        "out": "/nix/store/jnn5dwc1immwdasrk7bji7fdp32z1qvd-zizmor-1.12.1"
+        "out": "/nix/store/lr8pfsfx85dyl8l8hsrdcbrqgpaa212s-zizmor-1.22.0"
       },
       "system": "aarch64-linux",
       "group": "toplevel",
@@ -2709,27 +2713,27 @@
     {
       "attr_path": "zizmor",
       "broken": false,
-      "derivation": "/nix/store/d8w5yrsvvi2d7d3zzihnsn2xvcyg9rz8-zizmor-1.12.1.drv",
+      "derivation": "/nix/store/xv19mdsalfszf7k61v5mqmhzdq7hmfii-zizmor-1.22.0.drv",
       "description": "Tool for finding security issues in GitHub Actions setups",
       "install_id": "zizmor",
       "license": "MIT",
-      "locked_url": "https://github.com/flox/nixpkgs?rev=c23193b943c6c689d70ee98ce3128239ed9e32d1",
-      "name": "zizmor-1.12.1",
+      "locked_url": "https://github.com/flox/nixpkgs?rev=aca4d95fce4914b3892661bcb80b8087293536c6",
+      "name": "zizmor-1.22.0",
       "pname": "zizmor",
-      "rev": "c23193b943c6c689d70ee98ce3128239ed9e32d1",
-      "rev_count": 861038,
-      "rev_date": "2025-09-13T06:43:22Z",
-      "scrape_date": "2025-09-15T02:59:06.339772Z",
+      "rev": "aca4d95fce4914b3892661bcb80b8087293536c6",
+      "rev_count": 958961,
+      "rev_date": "2026-03-06T04:56:59Z",
+      "scrape_date": "2026-03-08T06:06:25.130823Z",
       "stabilities": [
         "unstable"
       ],
       "unfree": false,
-      "version": "1.12.1",
+      "version": "1.22.0",
       "outputs_to_install": [
         "out"
       ],
       "outputs": {
-        "out": "/nix/store/1v1vr1mimj94wwzv5n7awj7bq0hwk78b-zizmor-1.12.1"
+        "out": "/nix/store/grv48vjqys64mf8w5r22iy0d043sarw4-zizmor-1.22.0"
       },
       "system": "x86_64-darwin",
       "group": "toplevel",
@@ -2738,27 +2742,27 @@
     {
       "attr_path": "zizmor",
       "broken": false,
-      "derivation": "/nix/store/yzd1h4b8m4x0jx20yrdcyj1573brnis7-zizmor-1.12.1.drv",
+      "derivation": "/nix/store/hf07klcdpm3gsqrj3aicl6wxcy5b63zn-zizmor-1.22.0.drv",
       "description": "Tool for finding security issues in GitHub Actions setups",
       "install_id": "zizmor",
       "license": "MIT",
-      "locked_url": "https://github.com/flox/nixpkgs?rev=c23193b943c6c689d70ee98ce3128239ed9e32d1",
-      "name": "zizmor-1.12.1",
+      "locked_url": "https://github.com/flox/nixpkgs?rev=aca4d95fce4914b3892661bcb80b8087293536c6",
+      "name": "zizmor-1.22.0",
       "pname": "zizmor",
-      "rev": "c23193b943c6c689d70ee98ce3128239ed9e32d1",
-      "rev_count": 861038,
-      "rev_date": "2025-09-13T06:43:22Z",
-      "scrape_date": "2025-09-15T03:30:28.853084Z",
+      "rev": "aca4d95fce4914b3892661bcb80b8087293536c6",
+      "rev_count": 958961,
+      "rev_date": "2026-03-06T04:56:59Z",
+      "scrape_date": "2026-03-08T06:50:29.863418Z",
       "stabilities": [
         "unstable"
       ],
       "unfree": false,
-      "version": "1.12.1",
+      "version": "1.22.0",
       "outputs_to_install": [
         "out"
       ],
       "outputs": {
-        "out": "/nix/store/k4hhx6afl4r289kb44003x0l6hhd1wk5-zizmor-1.12.1"
+        "out": "/nix/store/1vsvi6yi3w1g479dxjv7pw5mb60qh96g-zizmor-1.22.0"
       },
       "system": "x86_64-linux",
       "group": "toplevel",

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,13 +7,17 @@ name: Continuous Integration
 
 permissions: {}
 
+concurrency:
+  group: "ci-${{ github.ref }}"
+  cancel-in-progress: true
+
 jobs:
   targets:
     name: Enumerate Just recipes
     runs-on: warp-ubuntu-latest-x64-2x
 
     permissions:
-      contents: read
+      contents: read # Checkout code
 
     outputs:
       matrix: ${{ steps.export-targets.outputs.targets }}
@@ -38,8 +42,8 @@ jobs:
     runs-on: warp-ubuntu-latest-x64-2x
 
     permissions:
-      packages: write
-      contents: read
+      packages: write # Push Docker images for visual regression
+      contents: read # Checkout code
 
     needs: targets
 
@@ -57,7 +61,7 @@ jobs:
       - name: Install Flox
         uses: flox/install-flox-action@9428713e8d3883274c334b4b95b8830beebd24d2 # 2.3.0
         with:
-          version: 1.6.1
+          version: 1.9.1
 
       - name: Remove Flox installer (if it exists)
         run: rm -f flox.x86_64-linux.deb

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -15,15 +15,19 @@ jobs:
       contains(github.event.comment.body, '@claude review')
 
     runs-on: warp-ubuntu-latest-x64-2x
+    concurrency:
+      group: "claude-review-${{ github.event.issue.number }}"
+      cancel-in-progress: true
+
     permissions:
-      contents: read
-      pull-requests: read
-      issues: read
-      id-token: write
+      contents: read # Checkout code
+      pull-requests: read # Read PR details
+      issues: read # Read issue comments
+      id-token: write # Authenticate with Claude
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           fetch-depth: 1
           persist-credentials: true

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -20,17 +20,21 @@ jobs:
       (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude') && !contains(github.event.review.body, '@claude review')) ||
       (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')) && !contains(github.event.issue.body, '@claude review') && !contains(github.event.issue.title, '@claude review'))
     runs-on: warp-ubuntu-latest-x64-2x
+    concurrency:
+      group: "claude-${{ github.event.issue.number || github.event.pull_request.number }}"
+      cancel-in-progress: true
+
     permissions:
-      contents: read
-      pull-requests: read
-      issues: read
-      id-token: write
-      actions: read # Required for Claude to read CI results on PRs
+      contents: read # Checkout code
+      pull-requests: read # Read PR details
+      issues: read # Read issue comments
+      id-token: write # Authenticate with Claude
+      actions: read # Read CI results on PRs
     name: Claude
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           fetch-depth: 1
           persist-credentials: true

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -32,9 +32,9 @@ jobs:
     name: Build Documentation
     runs-on: ubuntu-latest
     permissions:
-      contents: read
-      pages: write
-      id-token: write
+      contents: read # Checkout code
+      pages: write # Deploy to GitHub Pages
+      id-token: write # Authenticate with Pages
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # 6.0.2
@@ -44,7 +44,7 @@ jobs:
       - name: Install Flox
         uses: flox/install-flox-action@9428713e8d3883274c334b4b95b8830beebd24d2 # 2.3.0
         with:
-          version: 1.6.1
+          version: 1.9.1
 
       - name: Cache Rust dependencies
         uses: Swatinem/rust-cache@779680da715d629ac1d338a641029a2f4372abb5 # 2.8.2
@@ -93,9 +93,9 @@ jobs:
     runs-on: ubuntu-latest
     needs: build
     permissions:
-      contents: read
-      pages: write
-      id-token: write
+      contents: read # Access build artifacts
+      pages: write # Deploy to GitHub Pages
+      id-token: write # Authenticate with Pages
     steps:
       - name: Deploy to GitHub Pages
         id: deployment

--- a/.github/workflows/visual-regression.yml
+++ b/.github/workflows/visual-regression.yml
@@ -11,13 +11,17 @@ permissions: {}
       - "crates/kit/**"
       - "crates/kit-docs/**"
 
+concurrency:
+  group: "visual-regression-${{ github.ref }}"
+  cancel-in-progress: true
+
 jobs:
   visual-regression:
     name: Visual Regression
     runs-on: warp-ubuntu-latest-x64-2x
     permissions:
-      pull-requests: write
-      contents: read
+      pull-requests: write # Post regression report comments
+      contents: read # Checkout code
 
     steps:
       - name: Checkout PR
@@ -29,7 +33,7 @@ jobs:
       - name: Install Flox
         uses: flox/install-flox-action@9428713e8d3883274c334b4b95b8830beebd24d2 # 2.3.0
         with:
-          version: 1.6.1
+          version: 1.9.1
 
       - name: Remove Flox installer (if it exists)
         run: rm -f flox.x86_64-linux.deb

--- a/.zizmor.yml
+++ b/.zizmor.yml
@@ -1,0 +1,4 @@
+rules:
+  cache-poisoning:
+    ignore:
+      - visual-regression.yml

--- a/crates/kit/src/visual/separator.rs
+++ b/crates/kit/src/visual/separator.rs
@@ -1,16 +1,11 @@
 use leptos::prelude::*;
 
 /// Orientation options for the separator
-#[derive(Clone, Copy, PartialEq)]
+#[derive(Clone, Copy, Default, PartialEq)]
 pub enum Orientation {
+    #[default]
     Horizontal,
     Vertical,
-}
-
-impl Default for Orientation {
-    fn default() -> Self {
-        Self::Horizontal
-    }
 }
 
 /// A separator or divider that can be used to separate content

--- a/justfile
+++ b/justfile
@@ -86,7 +86,7 @@ format-yaml fix="false": (prettier fix "{yaml,yml}")
 
 # Lint GitHub Actions workflows
 lint-github-actions:
-    zizmor -p .
+    zizmor -p -c .zizmor.yml .
 
 # Lint Markdown files
 lint-markdown:


### PR DESCRIPTION
Upgrades the flox environment lock file, bringing Rust from 1.89 to 1.93 along with all other pinned packages (including zizmor 1.12→1.22).

The new zizmor is stricter — it exits non-zero on low findings that the old version silently ignored. This PR fixes all of them: adds permission comments to every workflow, adds concurrency groups to CI, claude, claude-code-review, and visual-regression workflows, pins the remaining unpinned `actions/checkout@v6` references in the Claude workflows, and adds a `.zizmor.yml` config (with `-c` flag in the justfile) for the existing cache-poisoning suppression.

Also bumps the `install-flox-action` version input from 1.6.1 to 1.9.1 across all workflows — Flox 1.6.1 has a known `LD_AUDIT`/jemalloc conflict that causes `cannot allocate memory in static TLS block` with Rust 1.93, fixed in Flox 1.7.8.

Fixes a new clippy lint in Rust 1.93 (`this impl can be derived`) on `Orientation` in the separator component.