### PR TITLE
Fix test-rust recipe and holt-macros crate ambiguity

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2187,7 +2187,7 @@ dependencies = [
  "console_log",
  "const_format",
  "holt-kit",
- "holt-macros 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "holt-macros",
  "inventory",
  "leptos",
  "leptos_meta",
@@ -2262,19 +2262,6 @@ dependencies = [
  "const_format",
  "holt-book",
  "leptos",
- "prettyplease",
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
-name = "holt-macros"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85210f3767b1f90ff59caaa25c2883f76cedcea3a990aa2a4a03c477ff5f8ddf"
-dependencies = [
- "const_format",
  "prettyplease",
  "proc-macro2",
  "quote",

--- a/crates/book/Cargo.toml
+++ b/crates/book/Cargo.toml
@@ -23,7 +23,7 @@ tailwind_fuse = { version = "0.3.0", features = ["variant"] }
 thiserror = ">=1.0.37, <2"
 markdown = "1.0.0"
 const_format = "0.2.34"
-holt-macros = "0.1.0"
+holt-macros = { path = "../story-macro", version = "0.1.0" }
 
 [dev-dependencies]
 holt-kit = { path = "../kit" }

--- a/justfile
+++ b/justfile
@@ -116,4 +116,5 @@ publish:
 
 # Run the tests
 test-rust:
-    cargo test --all-features --all-targets
+    cargo test --all-targets -p holt-kit -p holt-cli -p holt-macros
+    cargo test --all-targets -p holt-book -p holt-kit-docs --features ssr --no-default-features


### PR DESCRIPTION
The test-rust recipe used --all-features --all-targets which applied csr (wasm-bindgen) across the entire workspace via Cargo feature unification, breaking native compilation. This switches to testing crates individually with the correct feature flags — native crates get tested normally, while holt-book and holt-kit-docs get tested with SSR features.

Also resolves an ambiguity between the local and crates.io versions of holt-macros by adding a path+version dep in holt-book's Cargo.toml, so cargo test -p holt-macros works without confusion.