### PR TITLE
Ignore target/ in yamllint config

### DIFF
--- a/.yamllint.yaml
+++ b/.yamllint.yaml
@@ -7,6 +7,7 @@ ignore:
   - ".docusaurus/"
   - "docs/.docusaurus/"
   - "docs/build/"
+  - "target/"
 
 rules:
   document-start: disable


### PR DESCRIPTION
yamllint was scanning Rust build artifacts in target/ and finding YAML files to complain about. Added target/ to the ignore list.

🤖 Generated with [Claude Code](https://claude.com/claude-code)