### PR TITLE
Add release infrastructure

### DIFF
--- a/.github/labelflair.toml
+++ b/.github/labelflair.toml
@@ -1,0 +1,41 @@
+[[label]]
+name = "good-first-issue"
+description = "Good issue for newcomers - mentoring available"
+color = "#4ade80"
+
+[[group]]
+prefix = "A-"
+colors = { tailwind = "lime" }
+labels = [
+  { name = "kit", description = "An issue related to holt-kit" },
+  { name = "book", description = "An issue related to holt-book" },
+  { name = "macros", description = "An issue related to holt-macros" },
+  { name = "cli", description = "An issue related to holt-cli" },
+  { name = "docs", description = "An issue related to the documentation" },
+  { name = "github-actions", description = "An issue related to GitHub Actions" },
+]
+
+[[group]]
+prefix = "C-"
+colors = { tailwind = "red" }
+labels = [
+  { name = "bug", description = "Report a new bug" },
+  { name = "dependency", description = "Change or update a dependency" },
+  { name = "documentation", description = "Improve the documentation" },
+  { name = "feature", description = "Request a new feature", aliases = [
+    "feature-request",
+  ] },
+]
+
+[[group]]
+prefix = "R-"
+colors = { tailwind = "slate" }
+labels = [
+  { name = "added", description = "Add a new feature to the release notes" },
+  { name = "changed", description = "Add a change in existing functionality to the release notes" },
+  { name = "deprecated", description = "Add a soon-to-be removed feature to the release notes" },
+  { name = "fixed", description = "Add a fixed bug to the release notes" },
+  { name = "ignore", description = "Do not add this pull request to the release notes" },
+  { name = "removed", description = "Add a now removed feature to the release notes" },
+  { name = "security", description = "Add a vulnerability warning to the release notes" },
+]

--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,27 @@
+---
+# This file configures the automated releases notes for GitHub releases. See the
+# documentation for more information:
+# https://docs.github.com/en/repositories/releasing-projects-on-github/automatically-generated-release-notes
+changelog:
+  exclude:
+    labels:
+      - R-ignore
+  categories:
+    - title: Security
+      labels:
+        - R-security
+    - title: Added
+      labels:
+        - R-added
+    - title: Changed
+      labels:
+        - R-changed
+    - title: Deprecated
+      labels:
+        - R-deprecated
+    - title: Removed
+      labels:
+        - R-removed
+    - title: Fixed
+      labels:
+        - R-fixed

--- a/.github/workflows/labelflair.yml
+++ b/.github/workflows/labelflair.yml
@@ -1,0 +1,38 @@
+---
+name: Labelflair
+
+"on":
+  pull_request:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+permissions: {}
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  action:
+    name: Sync labels
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: read
+      issues: write # Required to manage labels
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # 6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Sync GitHub Issues labels
+        uses: jdno/labelflair@6a399c0d1fe3453fb2d7bdd2da30574cc1ab21b9 # v0.3.0
+        with:
+          config-file: .github/labelflair.toml
+          delete-other-labels: true
+          # Only run this step on the main branch to avoid creating labels in pull requests
+          dry-run: ${{ github.ref != 'refs/heads/main' }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,13 @@
+<!-- markdownlint-disable-file MD024 -->
+
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog], and this project adheres to [Semantic
+Versioning].
+
+## [Unreleased]
+
+[keep a changelog]: https://keepachangelog.com/en/1.0.0/
+[semantic versioning]: https://semver.org/spec/v2.0.0.html

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -40,6 +40,40 @@ These are installed via Flox.
 - Tailwind CSS via `tailwind_fuse`
 - `cargo install just trunk wasm-pack`
 
+## Releases
+
+Releases follow [Keep a Changelog](https://keepachangelog.com/) and
+[Semantic Versioning](https://semver.org/).
+
+1. Update `CHANGELOG.md`: move items from `[Unreleased]` into a new version
+   section dated today.
+2. Bump the version in the root `Cargo.toml` `[workspace.package]`.
+3. Run `cargo check` to update `Cargo.lock`.
+4. Commit, open a PR, and merge.
+5. Create a GitHub release with tag `vX.Y.Z` targeting main. The release
+   workflow automatically publishes to crates.io (`just publish` runs
+   `holt-macros` first, then `holt-book`, then `holt-cli`).
+
+Published crates: `holt-macros`, `holt-book`, `holt-cli`. The `holt-kit`,
+`holt-kit-docs`, `holt-regression`, and example crates are `publish = false`.
+
+### Labels
+
+PRs are categorized in release notes using these labels:
+
+| Label          | Release notes section |
+| -------------- | --------------------- |
+| `R-added`      | Added                 |
+| `R-changed`    | Changed               |
+| `R-deprecated` | Deprecated            |
+| `R-removed`    | Removed               |
+| `R-fixed`      | Fixed                 |
+| `R-security`   | Security              |
+| `R-ignore`     | Excluded              |
+
+Area labels: `A-kit`, `A-book`, `A-macros`, `A-cli`, `A-docs`,
+`A-github-actions`.
+
 ## gVisor / Cloud Sandbox Environments
 
 If `just` commands fail because `flox activate` crashes with


### PR DESCRIPTION
Ports the release process from clawless and doco into Holt. This adds GitHub's auto-generated release notes configuration, labelflair for managing issue/PR labels, a Keep a Changelog file, and documents the full release process in CLAUDE.md.

Tags will use the `vX.Y.Z` format (matching clawless). The publish workflow and justfile target were already in place — this fills in everything around them.

New files:
- `.github/release.yml` — release note categories keyed off R-* labels
- `.github/labelflair.toml` — label definitions (area, category, and release labels)
- `.github/workflows/labelflair.yml` — syncs labels from the toml config
- `CHANGELOG.md` — empty skeleton with `[Unreleased]`

🤖 Generated with [Claude Code](https://claude.com/claude-code)