### PR TITLE
Skip invalid feature combos in check-features

### DIFF
--- a/justfile
+++ b/justfile
@@ -30,7 +30,7 @@ check-docs:
 
 # Check features with cargo-hack
 check-features:
-    cargo hack --workspace --feature-powerset check --tests
+    cargo hack --workspace --feature-powerset --mutually-exclusive-features csr,ssr,hydrate check --tests
 
 # Check latest dependencies with cargo-update
 check-deps-latest:


### PR DESCRIPTION
The csr, ssr, and hydrate Leptos features are mutually exclusive rendering modes, but `cargo hack --feature-powerset` was testing every combination of them — most of which are meaningless. This made check-features the slowest CI job at ~17 minutes, nearly double the next slowest.

Adding `--mutually-exclusive-features csr,ssr,hydrate` tells cargo-hack to never combine those features, cutting the matrix from exponential to linear.

🤖 Generated with [Claude Code](https://claude.com/claude-code)