### PR TITLE
Add Renovate management for Flox version and pre-commit hooks

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -6,6 +6,20 @@
     fileMatch: ["Earthfile$"],
   },
 
+  "pre-commit": {
+    enabled: true,
+  },
+
+  customManagers: [
+    {
+      customType: "regex",
+      fileMatch: ["\\.github/workflows/.+\\.yml$"],
+      matchStrings: [
+        "# renovate: datasource=(?<datasource>\\S+) depName=(?<depName>\\S+)\\s+version:\\s+(?<currentValue>\\S+)",
+      ],
+    },
+  ],
+
   packageRules: [
     {
       matchPackagePatterns: ["^leptos"],

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,6 +61,7 @@ jobs:
       - name: Install Flox
         uses: flox/install-flox-action@9428713e8d3883274c334b4b95b8830beebd24d2 # 2.3.0
         with:
+          # renovate: datasource=github-releases depName=flox/flox
           version: 1.9.1
 
       - name: Remove Flox installer (if it exists)

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -44,6 +44,7 @@ jobs:
       - name: Install Flox
         uses: flox/install-flox-action@9428713e8d3883274c334b4b95b8830beebd24d2 # 2.3.0
         with:
+          # renovate: datasource=github-releases depName=flox/flox
           version: 1.9.1
 
       - name: Cache Rust dependencies

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -28,6 +28,9 @@ jobs:
 
       - name: Install Flox
         uses: flox/install-flox-action@9428713e8d3883274c334b4b95b8830beebd24d2 # 2.3.0
+        with:
+          # renovate: datasource=github-releases depName=flox/flox
+          version: 1.9.1
 
       - name: Remove Flox installer (if it exists)
         run: rm -f flox.x86_64-linux.deb

--- a/.github/workflows/visual-regression.yml
+++ b/.github/workflows/visual-regression.yml
@@ -44,6 +44,7 @@ jobs:
         if: steps.changed-files.outputs.any_changed == 'true'
         uses: flox/install-flox-action@9428713e8d3883274c334b4b95b8830beebd24d2 # 2.3.0
         with:
+          # renovate: datasource=github-releases depName=flox/flox
           version: 1.9.1
 
       - name: Remove Flox installer (if it exists)


### PR DESCRIPTION
A few version pins were slipping through without Renovate tracking them:

- The `version: 1.9.1` input to `flox/install-flox-action` in all four workflow files (ci, docs, visual-regression, publish). publish.yml wasn't pinning a version at all — it was just using whatever the action defaulted to. Added explicit pins with `# renovate:` inline annotations and a custom regex manager in the Renovate config.
- The `pre-commit/pre-commit-hooks` rev in `.pre-commit-config.yaml`. Renovate has a built-in pre-commit manager, it just needed to be enabled.

🤖 Generated with [Claude Code](https://claude.com/claude-code)