### PR TITLE
Prep v0.2.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,5 +9,58 @@ Versioning].
 
 ## [Unreleased]
 
+## [0.2.0] - 2026-03-11
+
+### Added
+
+- Add Dockerfile for kit-docs storybook (#448)
+- Add holt-regression crate for visual regression testing (#457)
+- Add source-level story scanner to holt-regression (#458)
+- Add --headless/--save/--check flags to `holt snapshot` (#460)
+- Add example crate and fix snapshot Caddy config (#463)
+- Add release infrastructure (#469)
+- Add Renovate management for Flox version and pre-commit hooks (#481)
+- Ship pre-compiled CSS from component libraries (#483)
+- Add end-to-end browser tests for kit-docs storybook (#485)
+
+### Changed
+
+- Remove storybook top bar, add mobile-only header (#400)
+- Migrate tests from wasm-bindgen-test to plain #[test] (#449)
+- Refactor CLI snapshot to use trunk + caddy via doco (#459)
+
+### Fixed
+
+- Fix mobile sidebar SSR + scroll containment (#401)
+- Fix test-rust recipe and holt-macros crate ambiguity (#455)
+- Fix visual regression check blocking unrelated PRs (#466)
+- Skip invalid feature combos in check-features (#470)
+- Fix inaccurate documentation across docs/ (#472, #486)
+- Add Tailwind CSS styling to basic example (#478)
+
+## [0.1.0] - 2026-02-16
+
+Initial release of Holt: a UI toolkit for Leptos implementing Shadcn/Radix-style
+components with behavior/presentation separation.
+
+**Components:** Badge, Breadcrumb, Button, Card, Checkbox, Collapsible, Input,
+Label, Select (with keyboard navigation and focus management), Separator,
+Switch, Textarea, Toggle, and Typography.
+
+**Storybook framework (holt-book):** Inventory-based story discovery, variant
+source code extraction and display, rustdoc-powered documentation, routing,
+sidebar navigation, and SSG support with hydration.
+
+**CLI (holt-cli):** `holt serve` for development with hot reloading,
+`holt build` for static builds, and `holt snapshot` for visual regression
+testing with headless Firefox via geckodriver.
+
+**Infrastructure:** Flox-based dev environment, visual regression CI with
+baseline comparison and PR comments, Docusaurus documentation site, and
+automated crates.io publishing workflow.
+
 [keep a changelog]: https://keepachangelog.com/en/1.0.0/
 [semantic versioning]: https://semver.org/spec/v2.0.0.html
+[unreleased]: https://github.com/aonyx-ai/holt/compare/v0.2.0...HEAD
+[0.2.0]: https://github.com/aonyx-ai/holt/compare/v0.1.0...v0.2.0
+[0.1.0]: https://github.com/aonyx-ai/holt/commits/v0.1.0

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2559,7 +2559,7 @@ checksum = "dfa686283ad6dd069f105e5ab091b04c62850d3e4cf5d67debad1933f55023df"
 
 [[package]]
 name = "holt-book"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "console_error_panic_hook",
  "console_log",
@@ -2579,7 +2579,7 @@ dependencies = [
 
 [[package]]
 name = "holt-cli"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "assert_cmd",
  "clawless",
@@ -2610,7 +2610,7 @@ dependencies = [
 
 [[package]]
 name = "holt-kit"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "console_error_panic_hook",
  "console_log",
@@ -2625,7 +2625,7 @@ dependencies = [
 
 [[package]]
 name = "holt-kit-docs"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "any_spawner",
  "console_error_panic_hook",
@@ -2651,7 +2651,7 @@ dependencies = [
 
 [[package]]
 name = "holt-macros"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "const_format",
  "holt-book",
@@ -2664,7 +2664,7 @@ dependencies = [
 
 [[package]]
 name = "holt-regression"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "doco",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ members = ["crates/*", "examples/*"]
 resolver = "2"
 
 [workspace.package]
-version = "0.1.0"
+version = "0.2.0"
 edition = "2024"
 
 description = "A UI toolkit for Leptos"

--- a/crates/book/Cargo.toml
+++ b/crates/book/Cargo.toml
@@ -23,7 +23,7 @@ tailwind_fuse = { version = "0.3.0", features = ["variant"] }
 thiserror = ">=1.0.37, <2"
 markdown = "1.0.0"
 const_format = "0.2.34"
-holt-macros = { path = "../story-macro", version = "0.1.0" }
+holt-macros = { path = "../story-macro", version = "0.2.0" }
 
 [dev-dependencies]
 holt-kit = { path = "../kit" }


### PR DESCRIPTION
Bumps the workspace version from 0.1.0 to 0.2.0 and adds a CHANGELOG.md covering both releases. The holt-macros version pin in holt-book's Cargo.toml is updated to match.

After merging, create a GitHub release with tag `v0.2.0` targeting main to trigger the crates.io publish workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)