### PR TITLE
Publish holt-regression to crates.io

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -57,10 +57,11 @@ Releases follow [Keep a Changelog](https://keepachangelog.com/) and
 4. Commit, open a PR, and merge.
 5. Create a GitHub release with tag `vX.Y.Z` targeting main. The release
    workflow automatically publishes to crates.io (`just publish` runs
-   `holt-macros` first, then `holt-book`, then `holt-cli`).
+   `holt-macros` first, then `holt-book`, then `holt-regression`, then
+   `holt-cli`).
 
-Published crates: `holt-macros`, `holt-book`, `holt-cli`. The `holt-kit`,
-`holt-kit-docs`, `holt-regression`, and example crates are `publish = false`.
+Published crates: `holt-macros`, `holt-book`, `holt-regression`, `holt-cli`. The
+`holt-kit`, `holt-kit-docs`, and example crates are `publish = false`.
 
 ### Labels
 

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -14,7 +14,7 @@ path = "src/main.rs"
 clawless = "0.5"
 doco = "0.2.3"
 eframe = "0.33"
-holt-regression = { path = "../regression" }
+holt-regression = { path = "../regression", version = "0.2.0" }
 image = { version = "0.25", features = ["png"] }
 serde = { version = "1", features = ["derive"] }
 tokio = { version = "1", features = ["process", "rt-multi-thread", "macros"] }

--- a/crates/regression/Cargo.toml
+++ b/crates/regression/Cargo.toml
@@ -3,7 +3,9 @@ name = "holt-regression"
 
 version.workspace = true
 edition.workspace = true
-publish = false
+description.workspace = true
+license.workspace = true
+repository.workspace = true
 
 [dependencies]
 anyhow = "1"

--- a/justfile
+++ b/justfile
@@ -128,6 +128,7 @@ generate-book-css:
 publish: generate-book-css
     cargo publish -p holt-macros -v --all-features
     cargo publish -p holt-book -v --all-features
+    cargo publish -p holt-regression -v --all-features
     cargo publish -p holt-cli -v --all-features
 
 # Run the tests


### PR DESCRIPTION
holt-cli depends on holt-regression, so it must be published for `cargo install holt-cli` to work. This adds it to the publish chain (between holt-book and holt-cli) and updates CLAUDE.md accordingly.

Discovered while attempting the v0.2.0 publish — cargo refused to publish holt-cli because holt-regression had no version specifier and was marked `publish = false`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)