### PR TITLE
Include pre-compiled CSS in published holt-book crate

### DIFF
--- a/crates/book/Cargo.toml
+++ b/crates/book/Cargo.toml
@@ -6,6 +6,7 @@ edition.workspace = true
 description.workspace = true
 license.workspace = true
 repository.workspace = true
+include = ["src/", "build.rs", "assets/holt-book.css"]
 
 [[bin]]
 name = "holt-book"


### PR DESCRIPTION
The gitignored `assets/holt-book.css` wasn't being included in the crates.io package, so downstream consumers got an empty `target/css/holt-book/` directory after `build.rs` ran. Adding an explicit `include` in Cargo.toml ensures the compiled CSS ships with the crate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)