### PR TITLE
Prep v0.2.1 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,13 @@ Versioning].
 
 ## [Unreleased]
 
+## [0.2.1] - 2026-03-11
+
+### Fixed
+
+- Include pre-compiled CSS in published holt-book crate (#489)
+- Publish holt-regression to crates.io so `cargo install holt-cli` works (#488)
+
 ## [0.2.0] - 2026-03-11
 
 ### Added
@@ -61,6 +68,7 @@ automated crates.io publishing workflow.
 
 [keep a changelog]: https://keepachangelog.com/en/1.0.0/
 [semantic versioning]: https://semver.org/spec/v2.0.0.html
-[unreleased]: https://github.com/aonyx-ai/holt/compare/v0.2.0...HEAD
+[unreleased]: https://github.com/aonyx-ai/holt/compare/v0.2.1...HEAD
+[0.2.1]: https://github.com/aonyx-ai/holt/compare/v0.2.0...v0.2.1
 [0.2.0]: https://github.com/aonyx-ai/holt/compare/v0.1.0...v0.2.0
 [0.1.0]: https://github.com/aonyx-ai/holt/commits/v0.1.0

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2559,7 +2559,7 @@ checksum = "dfa686283ad6dd069f105e5ab091b04c62850d3e4cf5d67debad1933f55023df"
 
 [[package]]
 name = "holt-book"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "console_error_panic_hook",
  "console_log",
@@ -2579,7 +2579,7 @@ dependencies = [
 
 [[package]]
 name = "holt-cli"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "assert_cmd",
  "clawless",
@@ -2610,7 +2610,7 @@ dependencies = [
 
 [[package]]
 name = "holt-kit"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "console_error_panic_hook",
  "console_log",
@@ -2625,7 +2625,7 @@ dependencies = [
 
 [[package]]
 name = "holt-kit-docs"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "any_spawner",
  "console_error_panic_hook",
@@ -2651,7 +2651,7 @@ dependencies = [
 
 [[package]]
 name = "holt-macros"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "const_format",
  "holt-book",
@@ -2664,7 +2664,7 @@ dependencies = [
 
 [[package]]
 name = "holt-regression"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "anyhow",
  "doco",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ members = ["crates/*", "examples/*"]
 resolver = "2"
 
 [workspace.package]
-version = "0.2.0"
+version = "0.2.1"
 edition = "2024"
 
 description = "A UI toolkit for Leptos"

--- a/crates/book/Cargo.toml
+++ b/crates/book/Cargo.toml
@@ -24,7 +24,7 @@ tailwind_fuse = { version = "0.3.0", features = ["variant"] }
 thiserror = ">=1.0.37, <2"
 markdown = "1.0.0"
 const_format = "0.2.34"
-holt-macros = { path = "../story-macro", version = "0.2.0" }
+holt-macros = { path = "../story-macro", version = "0.2.1" }
 
 [dev-dependencies]
 holt-kit = { path = "../kit" }

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -14,7 +14,7 @@ path = "src/main.rs"
 clawless = "0.5"
 doco = "0.2.3"
 eframe = "0.33"
-holt-regression = { path = "../regression", version = "0.2.0" }
+holt-regression = { path = "../regression", version = "0.2.1" }
 image = { version = "0.25", features = ["png"] }
 serde = { version = "1", features = ["derive"] }
 tokio = { version = "1", features = ["process", "rt-multi-thread", "macros"] }


### PR DESCRIPTION
Bumps workspace version to 0.2.1 with changelog entries for two publishing fixes:

- Include pre-compiled CSS in the published holt-book crate (#489) — the gitignored `assets/holt-book.css` wasn't making it into the crates.io package, leaving downstream consumers with an empty `target/css/holt-book/` directory.
- Publish holt-regression to crates.io (#488) — holt-cli depends on it, so `cargo install holt-cli` was broken without it.

Depends on #488 and #489. After merging, manually publish holt-regression (first-time crate, no trusted publishing yet), then create a GitHub release with tag `v0.2.1` to trigger the publish workflow for the rest.

🤖 Generated with [Claude Code](https://claude.com/claude-code)