### PR TITLE
Remove unused main.rs from basic example

### DIFF
--- a/examples/basic/src/main.rs
+++ b/examples/basic/src/main.rs
@@ -1,7 +1,0 @@
-// Import stories to register them with inventory
-#[allow(unused_imports)]
-use holt_example_basic::stories as _;
-
-fn main() {
-    holt_book::run_book();
-}


### PR DESCRIPTION
The basic example only runs via Trunk, which builds the `cdylib` library target (lib.rs) as the wasm entry point. The native binary in main.rs was dead code — it duplicated the same `holt_book::run_book()` call and required a `use stories as _` import just for inventory registration. One less file for users to think about.

🤖 Generated with [Claude Code](https://claude.com/claude-code)