### PR TITLE
Switch CI from Warp to GitHub-hosted runners

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ concurrency:
 jobs:
   targets:
     name: Enumerate Just recipes
-    runs-on: warp-ubuntu-latest-x64-2x
+    runs-on: ubuntu-latest
 
     permissions:
       contents: read # Checkout code
@@ -39,7 +39,7 @@ jobs:
 
   checks:
     name: ${{ matrix.target }}
-    runs-on: warp-ubuntu-latest-x64-2x
+    runs-on: ubuntu-latest
 
     permissions:
       packages: write # Push Docker images for visual regression
@@ -72,7 +72,6 @@ jobs:
         with:
           prefix-key: "v0-${{ matrix.target }}"
           cache-on-failure: true
-          cache-provider: "warpbuild"
 
       - name: Run check with Just
         uses: flox/activate-action@410568008895a0f2e09a34bbd9523f8ef1f2d292 # 1.1.0
@@ -81,7 +80,7 @@ jobs:
 
   success:
     name: All checks succeeded
-    runs-on: warp-ubuntu-latest-x64-2x
+    runs-on: ubuntu-latest
 
     permissions: {}
 

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -14,7 +14,7 @@ jobs:
       github.event.issue.pull_request &&
       contains(github.event.comment.body, '@claude review')
 
-    runs-on: warp-ubuntu-latest-x64-2x
+    runs-on: ubuntu-latest
     concurrency:
       group: "claude-review-${{ github.event.issue.number }}"
       cancel-in-progress: true

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -19,7 +19,7 @@ jobs:
       (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude') && !contains(github.event.comment.body, '@claude review')) ||
       (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude') && !contains(github.event.review.body, '@claude review')) ||
       (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')) && !contains(github.event.issue.body, '@claude review') && !contains(github.event.issue.title, '@claude review'))
-    runs-on: warp-ubuntu-latest-x64-2x
+    runs-on: ubuntu-latest
     concurrency:
       group: "claude-${{ github.event.issue.number || github.event.pull_request.number }}"
       cancel-in-progress: true

--- a/.github/workflows/visual-regression.yml
+++ b/.github/workflows/visual-regression.yml
@@ -13,7 +13,7 @@ concurrency:
 jobs:
   visual-regression:
     name: Visual Regression
-    runs-on: warp-ubuntu-latest-x64-2x
+    runs-on: ubuntu-latest
     permissions:
       pull-requests: write # Post regression report comments
       contents: read # Checkout code
@@ -57,7 +57,6 @@ jobs:
         with:
           prefix-key: "v0-visual-regression"
           cache-on-failure: true
-          cache-provider: "warpbuild"
 
       - name: Prepare baselines for comparison
         if: steps.changed-files.outputs.any_changed == 'true'


### PR DESCRIPTION
Now that the repo is public we get free GitHub Actions minutes, so there's no reason to keep paying for Warp's runners.

This replaces all `warp-ubuntu-latest-x64-2x` runner references with `ubuntu-latest` across the four workflows that were using them (CI, visual regression, and both Claude workflows), and drops the `cache-provider: "warpbuild"` config from Swatinem/rust-cache so it defaults to GitHub's built-in cache.

🤖 Generated with [Claude Code](https://claude.com/claude-code)