### PR TITLE
Add Alert component

### DIFF
--- a/crates/kit-docs/src/stories.rs
+++ b/crates/kit-docs/src/stories.rs
@@ -1,3 +1,4 @@
+mod alert;
 mod badge;
 mod breadcrumb;
 mod button;

--- a/crates/kit-docs/src/stories/alert.rs
+++ b/crates/kit-docs/src/stories/alert.rs
@@ -1,0 +1,60 @@
+// @component Alert
+#[cfg(feature = "e2e")]
+mod e2e;
+
+use holt_book::{story, variant};
+use holt_kit::visual::{Alert, AlertDescription, AlertTitle, AlertVariant};
+use leptos::prelude::*;
+use leptos_icons::Icon;
+
+#[variant]
+fn default() -> AnyView {
+    view! {
+        <Alert>
+            <AlertTitle>Heads up!</AlertTitle>
+            <AlertDescription>You can add components to your app using the CLI.</AlertDescription>
+        </Alert>
+    }
+    .into_any()
+}
+
+#[variant]
+fn destructive() -> AnyView {
+    view! {
+        <Alert variant=AlertVariant::Destructive>
+            <AlertTitle>Error</AlertTitle>
+            <AlertDescription>Your session has expired. Please log in again.</AlertDescription>
+        </Alert>
+    }
+    .into_any()
+}
+
+#[variant]
+fn with_icon() -> AnyView {
+    view! {
+        <Alert>
+            <Icon icon=icondata::LuTerminal />
+            <AlertTitle>Heads up!</AlertTitle>
+            <AlertDescription>You can add components to your app using the CLI.</AlertDescription>
+        </Alert>
+    }
+    .into_any()
+}
+
+#[variant]
+fn destructive_with_icon() -> AnyView {
+    view! {
+        <Alert variant=AlertVariant::Destructive>
+            <Icon icon=icondata::LuCircleAlert />
+            <AlertTitle>Error</AlertTitle>
+            <AlertDescription>Your session has expired. Please log in again.</AlertDescription>
+        </Alert>
+    }
+    .into_any()
+}
+
+include!(concat!(env!("OUT_DIR"), "/stories/alert_source.rs"));
+
+#[story(id = "alert", name = "Alert", extra_docs = ALERT_SOURCE)]
+/// Displays a callout for important information
+const ALERT_STORY: () = &[default, destructive, with_icon, destructive_with_icon];

--- a/crates/kit-docs/src/stories/alert/e2e.rs
+++ b/crates/kit-docs/src/stories/alert/e2e.rs
@@ -1,0 +1,39 @@
+use doco::{Client, Result};
+use thirtyfour::By;
+
+/// Alert component renders with the correct ARIA role.
+#[doco::test]
+async fn alert_renders_with_role(client: Client) -> Result<()> {
+    client.goto("/story/alert").await?;
+    tokio::time::sleep(std::time::Duration::from_millis(500)).await;
+
+    let alert = client.find(By::Css("main [role='alert']")).await?;
+    assert!(alert.is_displayed().await?);
+    Ok(())
+}
+
+/// Alert title renders with the correct data-slot attribute.
+#[doco::test]
+async fn alert_title_has_data_slot(client: Client) -> Result<()> {
+    client.goto("/story/alert").await?;
+    tokio::time::sleep(std::time::Duration::from_millis(500)).await;
+
+    let title = client
+        .find(By::Css("main [data-slot='alert-title']"))
+        .await?;
+    assert!(title.is_displayed().await?);
+    Ok(())
+}
+
+/// Alert description renders with the correct data-slot attribute.
+#[doco::test]
+async fn alert_description_has_data_slot(client: Client) -> Result<()> {
+    client.goto("/story/alert").await?;
+    tokio::time::sleep(std::time::Duration::from_millis(500)).await;
+
+    let desc = client
+        .find(By::Css("main [data-slot='alert-description']"))
+        .await?;
+    assert!(desc.is_displayed().await?);
+    Ok(())
+}

--- a/crates/kit/src/visual.rs
+++ b/crates/kit/src/visual.rs
@@ -1,5 +1,6 @@
 //! Components are reusable elements
 
+pub use self::alert::*;
 pub use self::badge::*;
 pub use self::breadcrumb::*;
 pub use self::button::*;
@@ -16,6 +17,7 @@ pub use self::textarea::*;
 pub use self::toggle::*;
 pub use self::typography::*;
 
+mod alert;
 mod badge;
 mod breadcrumb;
 mod button;

--- a/crates/kit/src/visual/alert.rs
+++ b/crates/kit/src/visual/alert.rs
@@ -1,0 +1,73 @@
+use leptos::prelude::*;
+use tailwind_fuse::*;
+
+#[derive(TwClass)]
+#[tw(
+    class = "relative w-full rounded-lg border px-4 py-3 text-sm grid has-[>svg]:grid-cols-[calc(var(--spacing)*4)_1fr] grid-cols-[0_1fr] has-[>svg]:gap-x-3 gap-y-0.5 items-start [&>svg]:size-4 [&>svg]:translate-y-0.5 [&>svg]:text-current"
+)]
+struct AlertStyle {
+    variant: AlertVariant,
+}
+
+#[derive(TwVariant)]
+pub enum AlertVariant {
+    #[tw(default, class = "bg-card text-foreground [&>svg]:text-current")]
+    Default,
+    #[tw(
+        class = "text-destructive bg-card [&>svg]:text-current *:data-[slot=alert-description]:text-destructive/90"
+    )]
+    Destructive,
+}
+
+#[component]
+pub fn Alert(
+    #[prop(optional, into)] class: String,
+    #[prop(optional)] variant: AlertVariant,
+    children: Children,
+) -> impl IntoView {
+    let final_class = AlertStyle { variant }.with_class(class);
+    view! {
+        <div class=final_class role="alert">
+            {children()}
+        </div>
+    }
+}
+
+#[component]
+pub fn AlertTitle(#[prop(optional, into)] class: String, children: Children) -> impl IntoView {
+    let classes = tw_merge!(
+        "col-start-2 font-medium leading-none tracking-tight",
+        &class
+    );
+    view! {
+        <h5 class=classes data-slot="alert-title">
+            {children()}
+        </h5>
+    }
+}
+
+#[component]
+pub fn AlertDescription(
+    #[prop(optional, into)] class: String,
+    children: Children,
+) -> impl IntoView {
+    let classes = tw_merge!(
+        "col-start-2 text-sm text-muted-foreground [&_p]:leading-relaxed",
+        &class
+    );
+    view! {
+        <div class=classes data-slot="alert-description">
+            {children()}
+        </div>
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn class_prop_accepts_str_and_string() {
+        assert_class_prop!(AlertProps, AlertTitleProps, AlertDescriptionProps);
+    }
+}


### PR DESCRIPTION
MVP implementation of the Alert component with default and destructive variants, plus AlertTitle and AlertDescription subcomponents. Visual-only with Tailwind styling via tailwind_fuse, storybook story, unit tests, and e2e tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)